### PR TITLE
feat: replace start.bat console window with PySide6 launcher

### DIFF
--- a/docs/plans/2026-02-22-launcher-design.md
+++ b/docs/plans/2026-02-22-launcher-design.md
@@ -1,0 +1,112 @@
+# Launcher Design: PySide6 GUI Launcher to Replace start.bat Console Window
+
+**Date:** 2026-02-22
+**Status:** Approved
+
+## Problem
+
+Two related UX issues with the current `start.bat` approach:
+
+1. **Black console window persists** — After the GUI opens, the cmd window stays alive (it must, to keep the process running). Users cannot close it without killing the app.
+2. **pip install is silent** — First-time install with `-q` flag shows nothing. Users think the app is frozen.
+
+## Solution
+
+Replace the heavy `start.bat` startup logic with a small PySide6 `launcher.py`, invoked via `pythonw.exe` (which has no console window). The launcher window handles git pull and pip install with real-time output, then hands off to the main GUI.
+
+## Architecture
+
+```
+start.bat  (trimmed to ~10 lines: UAC elevation only)
+  └─→ toolkit\python\pythonw.exe launcher.py
+        ├─ Shows LauncherWindow immediately
+        ├─ Worker thread: git pull  → streams output to window
+        ├─ Worker thread: pip install → streams output to window
+        └─ On success: subprocess gui_main.py, then self.close()
+```
+
+## Components
+
+### `start.bat` (trimmed)
+
+Responsibilities reduced to:
+- UAC elevation via PowerShell if not already admin
+- Set PATH to `toolkit\python` and `toolkit\git\cmd`
+- Run `toolkit\python\pythonw.exe launcher.py`
+- Exit (does not wait for launcher)
+
+### `launcher.py` (new file, project root)
+
+A standalone PySide6 application (~150 lines):
+- Creates `QApplication` and shows `LauncherWindow`
+- Runs update steps sequentially in a `QThread` worker
+- On success, launches `gui_main.py` via `subprocess.Popen` and exits
+
+### `gui/launcher_window.py` (new file)
+
+`LauncherWindow(QWidget)`:
+- Fixed small window (~420×200px), no resize, no taskbar entry (`Qt.Tool`)
+- Centered on screen
+- Shows: app icon, title, status label, progress bar, scrolling log output
+- Emits signals from worker thread to update UI safely
+
+### Worker Thread
+
+Runs sequentially:
+1. `git pull --ff-only` — captures stdout/stderr line by line, emits to log
+2. `pip install -r requirements.txt --progress-bar on` — captures output line by line, emits to log
+3. Emits `finished` signal on success or `error` signal on failure
+
+### Error Handling
+
+- `git pull` failure: show warning in log, continue to pip install (non-blocking, same as current behavior)
+- `pip install` failure: show error dialog, do not launch main GUI (blocking, same as current behavior)
+
+## UI Layout
+
+```
+┌──────────────────────────────────────────┐
+│  [icon]  Tthol Reader                    │
+│                                          │
+│  正在檢查更新...                          │
+│  ████████████░░░░░░░░  60%              │
+│                                          │
+│  > Already up to date.                  │
+│  > Installing psutil-7.2.2...           │
+│  > Successfully installed psutil-7.2.2  │
+└──────────────────────────────────────────┘
+```
+
+- Log area: read-only, auto-scrolls to bottom, monospace font, max ~4 visible lines
+- Progress bar: indeterminate during git pull, step-based during pip install
+
+## pip install Progress
+
+Remove the `-q` flag. Use `--progress-bar on` and parse output lines:
+- Lines matching `Installing ...` increment the progress bar
+- Lines matching `Successfully installed` shown in log
+- All output streamed in real time (no buffering)
+
+## What Does NOT Change
+
+- UAC elevation logic stays in `start.bat`
+- PATH setup (`toolkit\python`, `toolkit\git\cmd`) stays in `start.bat`
+- `gui_main.py` is unchanged — launcher just `Popen`s it and exits
+- GitHub Actions release workflow unchanged
+- `requirements.txt` unchanged
+
+## Trade-offs Considered
+
+| Approach | Verdict |
+|---|---|
+| VBScript wrapper | Rejected — Windows security warnings, not professional |
+| Compiled Go/C# EXE | Rejected — adds language dependency to CI/CD |
+| pythonw + PySide6 launcher | **Chosen** — uses existing stack, no new dependencies |
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `start.bat` | Trim to ~10 lines (UAC + PATH + pythonw call) |
+| `launcher.py` | New — entry point, creates QApplication |
+| `gui/launcher_window.py` | New — LauncherWindow widget + worker thread |

--- a/docs/plans/2026-02-22-launcher-impl.md
+++ b/docs/plans/2026-02-22-launcher-impl.md
@@ -1,0 +1,503 @@
+# PySide6 Launcher Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace `start.bat`'s console-window-producing update logic with a PySide6 launcher window that shows real-time git pull / pip install output, then hands off to the main GUI — no black window left behind.
+
+**Architecture:** A new `launcher.py` entry point is invoked via `pythonw.exe` (no console). It shows `gui/launcher_window.py`, which runs an `UpdateWorker` QThread that streams subprocess output to the UI. On success, `gui_main.py` is started via `subprocess.Popen` and the launcher exits.
+
+**Tech Stack:** PySide6 (QThread, QProcess-style signals), Python subprocess, existing `gui/theme.py` palette constants for colours.
+
+---
+
+## Task 1: pip output filter helper (TDD first)
+
+This helper decides which pip output lines are worth showing to the user. It's pure logic — no GUI — so we test it first.
+
+**Files:**
+- Create: `gui/launcher_window.py` (just the helper for now)
+- Create: `tests/test_launcher_window.py`
+
+**Step 1: Write the failing test**
+
+Create `tests/test_launcher_window.py`:
+
+```python
+"""Tests for launcher window helpers."""
+from gui.launcher_window import format_pip_line
+
+
+def test_skips_already_satisfied():
+    assert format_pip_line("Requirement already satisfied: psutil in ...") is None
+
+
+def test_skips_empty_line():
+    assert format_pip_line("") is None
+    assert format_pip_line("   ") is None
+
+
+def test_keeps_installing_line():
+    result = format_pip_line("Installing collected packages: psutil")
+    assert result == "Installing collected packages: psutil"
+
+
+def test_keeps_successfully_installed():
+    result = format_pip_line("Successfully installed psutil-7.2.2")
+    assert result == "Successfully installed psutil-7.2.2"
+
+
+def test_keeps_error_line():
+    result = format_pip_line("ERROR: Could not find a version that satisfies")
+    assert result == "ERROR: Could not find a version that satisfies"
+
+
+def test_skips_downloading_line():
+    assert format_pip_line("Downloading psutil-7.2.2-cp311-win32.whl (380 kB)") is None
+
+
+def test_strips_trailing_whitespace():
+    result = format_pip_line("Successfully installed psutil-7.2.2   \n")
+    assert result == "Successfully installed psutil-7.2.2"
+```
+
+**Step 2: Run test to verify it fails**
+
+```
+uv run pytest tests/test_launcher_window.py -v
+```
+
+Expected: `ImportError` — `gui/launcher_window.py` does not exist yet.
+
+**Step 3: Create `gui/launcher_window.py` with just the helper**
+
+```python
+"""PySide6 launcher window: shows update progress before starting the main GUI."""
+
+from __future__ import annotations
+
+
+_SKIP_PREFIXES = (
+    "Requirement already satisfied",
+    "Downloading ",
+    "Using cached ",
+    "Obtaining ",
+    "  Downloading",
+)
+
+
+def format_pip_line(line: str) -> str | None:
+    """Return a cleaned pip output line to display, or None to skip it."""
+    stripped = line.strip()
+    if not stripped:
+        return None
+    for prefix in _SKIP_PREFIXES:
+        if stripped.startswith(prefix):
+            return None
+    return stripped
+```
+
+**Step 4: Run test to verify it passes**
+
+```
+uv run pytest tests/test_launcher_window.py -v
+```
+
+Expected: all 7 tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add gui/launcher_window.py tests/test_launcher_window.py
+git commit -m "feat: add launcher_window module with pip line filter helper (TDD)"
+```
+
+---
+
+## Task 2: UpdateWorker QThread
+
+Add the background thread that runs git pull then pip install, streaming output via Qt signals.
+
+**Files:**
+- Modify: `gui/launcher_window.py` — append UpdateWorker class
+
+**Step 1: Append UpdateWorker to `gui/launcher_window.py`**
+
+Add these imports at the top of the file (after `from __future__ import annotations`):
+
+```python
+import subprocess
+import sys
+from pathlib import Path
+
+from PySide6.QtCore import QThread, Signal
+```
+
+Then append the class at the bottom of the file:
+
+```python
+class UpdateWorker(QThread):
+    """Runs git pull then pip install in a background thread."""
+
+    line_ready = Signal(str)   # a single line to append to the log
+    status_changed = Signal(str)  # short status label text
+    finished = Signal()        # all steps succeeded
+    failed = Signal(str)       # fatal error message (pip install failed)
+
+    def run(self) -> None:
+        self._run_git()
+        self._run_pip()
+
+    # ── git ──────────────────────────────────────────────────────────────────
+
+    def _run_git(self) -> None:
+        self.status_changed.emit("Checking for updates...")
+
+        # Fix detached HEAD (happens on first run after zip extraction)
+        check = subprocess.run(
+            ["git", "symbolic-ref", "HEAD"],
+            capture_output=True,
+        )
+        if check.returncode != 0:
+            self.line_ready.emit("Detached HEAD detected, switching to main branch...")
+            subprocess.run(["git", "checkout", "main"], capture_output=True)
+            subprocess.run(
+                ["git", "branch", "--set-upstream-to=origin/main", "main"],
+                capture_output=True,
+            )
+
+        # git pull
+        proc = subprocess.Popen(
+            ["git", "pull", "--ff-only"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        for raw_line in proc.stdout:
+            self.line_ready.emit(raw_line.rstrip())
+        proc.wait()
+
+        if proc.returncode != 0:
+            self.line_ready.emit("WARNING: git pull failed. Running with current version.")
+
+    # ── pip ──────────────────────────────────────────────────────────────────
+
+    def _run_pip(self) -> None:
+        self.status_changed.emit("Syncing dependencies...")
+
+        req = Path(__file__).parent.parent / "requirements.txt"
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-m", "pip", "install",
+                "-r", str(req),
+                "--progress-bar", "off",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        for raw_line in proc.stdout:
+            display = format_pip_line(raw_line)
+            if display:
+                self.line_ready.emit(display)
+        proc.wait()
+
+        if proc.returncode != 0:
+            self.failed.emit("pip install failed. Cannot start the application.")
+            return
+
+        self.finished.emit()
+```
+
+**Step 2: Verify the file has no syntax errors**
+
+```
+uv run python -c "from gui.launcher_window import UpdateWorker; print('OK')"
+```
+
+Expected: `OK`
+
+**Step 3: Run existing tests to make sure nothing broke**
+
+```
+uv run pytest tests/test_launcher_window.py -v
+```
+
+Expected: all 7 tests still PASS.
+
+**Step 4: Commit**
+
+```bash
+git add gui/launcher_window.py
+git commit -m "feat: add UpdateWorker QThread to launcher_window"
+```
+
+---
+
+## Task 3: LauncherWindow widget
+
+Build the visible window that displays the worker's output.
+
+**Files:**
+- Modify: `gui/launcher_window.py` — append LauncherWindow class
+
+**Step 1: Add Qt widget imports at the top of the file**
+
+After the existing PySide6 imports, add:
+
+```python
+from PySide6.QtGui import QFont, QIcon
+from PySide6.QtWidgets import (
+    QLabel,
+    QPlainTextEdit,
+    QProgressBar,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+from PySide6.QtCore import Qt
+```
+
+**Step 2: Append LauncherWindow at the bottom of the file**
+
+```python
+class LauncherWindow(QWidget):
+    """Small update-progress window shown before the main GUI launches."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Tthol Reader")
+        self.setFixedSize(460, 220)
+        self.setWindowFlags(Qt.WindowType.Window | Qt.WindowType.WindowTitleHint)
+
+        icon_path = Path(__file__).parent.parent / "icon.png"
+        if icon_path.exists():
+            self.setWindowIcon(QIcon(str(icon_path)))
+
+        self._build_ui()
+        self._start_worker()
+
+    # ── UI ───────────────────────────────────────────────────────────────────
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 16, 16, 12)
+        layout.setSpacing(8)
+
+        self._status = QLabel("Starting...")
+        self._status.setAlignment(Qt.AlignmentFlag.AlignLeft)
+
+        self._bar = QProgressBar()
+        self._bar.setRange(0, 0)   # indeterminate (marquee)
+        self._bar.setTextVisible(False)
+        self._bar.setFixedHeight(6)
+
+        self._log = QPlainTextEdit()
+        self._log.setReadOnly(True)
+        self._log.setMaximumBlockCount(200)
+        self._log.setFixedHeight(100)
+        mono = QFont("Consolas", 8)
+        mono.setStyleHint(QFont.StyleHint.Monospace)
+        self._log.setFont(mono)
+
+        layout.addWidget(self._status)
+        layout.addWidget(self._bar)
+        layout.addWidget(self._log)
+
+    # ── Worker wiring ─────────────────────────────────────────────────────────
+
+    def _start_worker(self) -> None:
+        self._worker = UpdateWorker()
+        self._worker.line_ready.connect(self._append_log)
+        self._worker.status_changed.connect(self._status.setText)
+        self._worker.finished.connect(self._on_success)
+        self._worker.failed.connect(self._on_failure)
+        self._worker.start()
+
+    def _append_log(self, line: str) -> None:
+        self._log.appendPlainText(line)
+        self._log.verticalScrollBar().setValue(
+            self._log.verticalScrollBar().maximum()
+        )
+
+    def _on_success(self) -> None:
+        self._bar.setRange(0, 1)
+        self._bar.setValue(1)
+        self._status.setText("Launching...")
+        # Launch main GUI as detached process so it survives launcher exit
+        subprocess.Popen(
+            [sys.executable, str(Path(__file__).parent.parent / "gui_main.py")],
+            close_fds=True,
+        )
+        self.close()
+
+    def _on_failure(self, message: str) -> None:
+        self._bar.setRange(0, 1)
+        self._bar.setValue(0)
+        self._status.setText("Error — cannot start")
+        self._append_log(f"\nERROR: {message}")
+        # Add a close button so user can dismiss
+        btn = QPushButton("Close")
+        btn.clicked.connect(self.close)
+        self.layout().addWidget(btn)
+```
+
+**Step 3: Verify the file has no syntax errors**
+
+```
+uv run python -c "from gui.launcher_window import LauncherWindow; print('OK')"
+```
+
+Expected: `OK`
+
+**Step 4: Run existing tests**
+
+```
+uv run pytest tests/test_launcher_window.py -v
+```
+
+Expected: all 7 tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add gui/launcher_window.py
+git commit -m "feat: add LauncherWindow widget to launcher_window"
+```
+
+---
+
+## Task 4: `launcher.py` entry point
+
+The file that `pythonw.exe` actually runs.
+
+**Files:**
+- Create: `launcher.py` (project root)
+
+**Step 1: Create `launcher.py`**
+
+```python
+"""Launcher entry point — run via pythonw.exe to avoid a console window.
+
+Sequence:
+1. Show LauncherWindow (git pull + pip install with live output).
+2. On success, LauncherWindow starts gui_main.py and exits.
+"""
+
+import sys
+from PySide6.QtWidgets import QApplication
+from gui.launcher_window import LauncherWindow
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    app.setApplicationName("Tthol Reader")
+    window = LauncherWindow()
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()
+```
+
+**Step 2: Verify the file has no syntax errors**
+
+```
+uv run python -c "import launcher; print('OK')"
+```
+
+Expected: `OK`
+
+**Step 3: Commit**
+
+```bash
+git add launcher.py
+git commit -m "feat: add launcher.py entry point for pythonw.exe"
+```
+
+---
+
+## Task 5: Trim `start.bat`
+
+Remove all update logic from `start.bat`. The bat now only handles UAC elevation, sets up PATH, and calls `pythonw.exe launcher.py`.
+
+**Files:**
+- Modify: `start.bat`
+
+**Step 1: Replace the entire contents of `start.bat`**
+
+```bat
+@echo off
+setlocal EnableDelayedExpansion
+
+:: ── UAC elevation ─────────────────────────────────────────────────────────
+:: If not running as admin, re-launch with elevation and exit.
+net session >nul 2>&1
+if %errorlevel% neq 0 (
+    powershell -Command "Start-Process -FilePath '%~f0' -Verb RunAs"
+    exit /b
+)
+
+:: ── Paths ──────────────────────────────────────────────────────────────────
+set "_root=%~dp0"
+set "PATH=%_root%toolkit\python;%_root%toolkit\python\Scripts;%_root%toolkit\git\cmd;%PATH%"
+set "PYTHONPATH=%_root%"
+
+cd /d "%_root%"
+
+:: ── Launch launcher (pythonw = no console window) ─────────────────────────
+start "" "%_root%toolkit\python\pythonw.exe" "%_root%launcher.py"
+```
+
+Note: `start ""` is used so that `start.bat` itself exits immediately after spawning `pythonw.exe`. The empty string `""` is the window title argument required by `start`.
+
+**Step 2: Manual smoke test**
+
+> This step cannot be automated — it requires a real game session with the toolkit folder present.
+> Double-click `start.bat`. Verify:
+> - No black console window appears or disappears immediately
+> - The LauncherWindow appears
+> - git pull output is shown in the log
+> - pip install output is shown (or "Requirement already satisfied" lines are hidden)
+> - After completion, the main GUI opens
+> - The LauncherWindow closes
+
+**Step 3: Commit**
+
+```bash
+git add start.bat
+git commit -m "feat: trim start.bat to UAC + pythonw launcher call only"
+```
+
+---
+
+## Task 6: Verify and cleanup
+
+**Step 1: Run full test suite**
+
+```
+uv run pytest -v
+```
+
+Expected: all tests PASS (no regressions).
+
+**Step 2: Check for leftover references to old logic**
+
+```
+grep -r "pip install" start.bat
+grep -r "git pull" start.bat
+```
+
+Expected: no matches (all that logic is now in `UpdateWorker`).
+
+**Step 3: Final commit if any cleanup needed**
+
+```bash
+git add -p
+git commit -m "chore: cleanup after launcher refactor"
+```

--- a/gui/launcher_window.py
+++ b/gui/launcher_window.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
+from pathlib import Path
+
+from PySide6.QtCore import QThread, Signal
+
 
 _SKIP_PREFIXES = (
     "Requirement already satisfied",
@@ -20,3 +26,85 @@ def format_pip_line(line: str) -> str | None:
         if stripped.startswith(prefix):
             return None
     return stripped
+
+
+class UpdateWorker(QThread):
+    """Runs git pull then pip install in a background thread."""
+
+    line_ready = Signal(str)  # a single line to append to the log
+    status_changed = Signal(str)  # short status label text
+    finished = Signal()  # all steps succeeded
+    failed = Signal(str)  # fatal error message (pip install failed)
+
+    def run(self) -> None:
+        self._run_git()
+        self._run_pip()
+
+    # ── git ──────────────────────────────────────────────────────────────────
+
+    def _run_git(self) -> None:
+        self.status_changed.emit("Checking for updates...")
+
+        # Fix detached HEAD (happens on first run after zip extraction)
+        check = subprocess.run(
+            ["git", "symbolic-ref", "HEAD"],
+            capture_output=True,
+        )
+        if check.returncode != 0:
+            self.line_ready.emit("Detached HEAD detected, switching to main branch...")
+            subprocess.run(["git", "checkout", "main"], capture_output=True)
+            subprocess.run(
+                ["git", "branch", "--set-upstream-to=origin/main", "main"],
+                capture_output=True,
+            )
+
+        # git pull
+        proc = subprocess.Popen(
+            ["git", "pull", "--ff-only"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        for raw_line in proc.stdout:
+            self.line_ready.emit(raw_line.rstrip())
+        proc.wait()
+
+        if proc.returncode != 0:
+            self.line_ready.emit("WARNING: git pull failed. Running with current version.")
+
+    # ── pip ──────────────────────────────────────────────────────────────────
+
+    def _run_pip(self) -> None:
+        self.status_changed.emit("Syncing dependencies...")
+
+        req = Path(__file__).parent.parent / "requirements.txt"
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "-r",
+                str(req),
+                "--progress-bar",
+                "off",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+        for raw_line in proc.stdout:
+            display = format_pip_line(raw_line)
+            if display:
+                self.line_ready.emit(display)
+        proc.wait()
+
+        if proc.returncode != 0:
+            self.failed.emit("pip install failed. Cannot start the application.")
+            return
+
+        self.finished.emit()

--- a/gui/launcher_window.py
+++ b/gui/launcher_window.py
@@ -190,12 +190,18 @@ class LauncherWindow(QWidget):
         self._status.setText("Launching...")
         subprocess.Popen(
             [sys.executable, str(Path(__file__).parent.parent / "gui_main.py")],
-            creationflags=0x00000008,  # DETACHED_PROCESS — survives launcher exit on Windows
+            creationflags=subprocess.DETACHED_PROCESS,
             close_fds=True,
         )
         self._worker.quit()
         self._worker.wait()
         self.close()
+
+    def closeEvent(self, event) -> None:
+        if self._worker.isRunning():
+            self._worker.quit()
+            self._worker.wait()
+        super().closeEvent(event)
 
     def _on_failure(self, message: str) -> None:
         self._bar.setRange(0, 1)

--- a/gui/launcher_window.py
+++ b/gui/launcher_window.py
@@ -1,0 +1,23 @@
+"""PySide6 launcher window: shows update progress before starting the main GUI."""
+
+from __future__ import annotations
+
+
+_SKIP_PREFIXES = (
+    "Requirement already satisfied",
+    "Downloading ",
+    "Using cached ",
+    "Obtaining ",
+    "  Downloading",
+)
+
+
+def format_pip_line(line: str) -> str | None:
+    """Return a cleaned pip output line to display, or None to skip it."""
+    stripped = line.strip()
+    if not stripped:
+        return None
+    for prefix in _SKIP_PREFIXES:
+        if stripped.startswith(prefix):
+            return None
+    return stripped

--- a/gui/launcher_window.py
+++ b/gui/launcher_window.py
@@ -37,8 +37,11 @@ class UpdateWorker(QThread):
     failed = Signal(str)  # fatal error message (pip install failed)
 
     def run(self) -> None:
-        self._run_git()
-        self._run_pip()
+        try:
+            self._run_git()
+            self._run_pip()
+        except Exception as exc:
+            self.failed.emit(f"Unexpected error: {exc}")
 
     # ── git ──────────────────────────────────────────────────────────────────
 

--- a/gui/launcher_window.py
+++ b/gui/launcher_window.py
@@ -8,7 +8,6 @@ _SKIP_PREFIXES = (
     "Downloading ",
     "Using cached ",
     "Obtaining ",
-    "  Downloading",
 )
 
 

--- a/launcher.py
+++ b/launcher.py
@@ -1,0 +1,22 @@
+"""Launcher entry point — run via pythonw.exe to avoid a console window.
+
+Sequence:
+1. Show LauncherWindow (git pull + pip install with live output).
+2. On success, LauncherWindow starts gui_main.py and exits.
+"""
+
+import sys
+from PySide6.QtWidgets import QApplication
+from gui.launcher_window import LauncherWindow
+
+
+def main() -> None:
+    app = QApplication(sys.argv)
+    app.setApplicationName("Tthol Reader")
+    window = LauncherWindow()
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/start.bat
+++ b/start.bat
@@ -1,59 +1,20 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-:: ── UAC elevation ────────────────────────────────────────────────────
+:: ── UAC elevation ─────────────────────────────────────────────────────────
 :: If not running as admin, re-launch with elevation and exit.
 net session >nul 2>&1
 if %errorlevel% neq 0 (
-    echo Requesting administrator privileges...
     powershell -Command "Start-Process -FilePath '%~f0' -Verb RunAs"
     exit /b
 )
 
-:: ── Paths ─────────────────────────────────────────────────────
+:: ── Paths ──────────────────────────────────────────────────────────────────
 set "_root=%~dp0"
 set "PATH=%_root%toolkit\python;%_root%toolkit\python\Scripts;%_root%toolkit\git\cmd;%PATH%"
 set "PYTHONPATH=%_root%"
 
 cd /d "%_root%"
 
-:: ── Update ────────────────────────────────────────────────────
-title Tthol Reader - Updating...
-echo [1/2] Pulling latest code...
-
-:: If in detached HEAD (e.g. first run after extracting release zip), switch to main.
-git symbolic-ref HEAD >nul 2>&1
-if %errorlevel% neq 0 (
-    echo Detached HEAD detected, switching to main branch...
-    git checkout main >nul 2>&1
-    if %errorlevel% neq 0 (
-        git checkout -b main origin/main >nul 2>&1
-    )
-    git branch --set-upstream-to=origin/main main >nul 2>&1
-)
-
-git pull --ff-only
-if %errorlevel% neq 0 (
-    echo.
-    echo WARNING: git pull failed. Running with current version.
-    echo Press any key to continue anyway...
-    pause >nul
-)
-
-echo [2/2] Syncing dependencies...
-python -m pip install -r requirements.txt -q
-if %errorlevel% neq 0 (
-    echo.
-    echo ERROR: pip install failed. Cannot continue.
-    pause
-    exit /b 1
-)
-
-:: ── Launch ────────────────────────────────────────────────────
-title Tthol Reader
-python gui_main.py
-if %errorlevel% neq 0 (
-    echo.
-    echo Application exited with an error.
-    pause
-)
+:: ── Launch launcher (pythonw = no console window) ─────────────────────────
+start "" "%_root%toolkit\python\pythonw.exe" "%_root%launcher.py"

--- a/start.bat
+++ b/start.bat
@@ -1,5 +1,5 @@
 @echo off
-setlocal EnableDelayedExpansion
+setlocal
 
 :: ── UAC elevation ─────────────────────────────────────────────────────────
 :: If not running as admin, re-launch with elevation and exit.

--- a/tests/test_launcher_window.py
+++ b/tests/test_launcher_window.py
@@ -1,0 +1,36 @@
+"""Tests for launcher window helpers."""
+
+from gui.launcher_window import format_pip_line
+
+
+def test_skips_already_satisfied():
+    assert format_pip_line("Requirement already satisfied: psutil in ...") is None
+
+
+def test_skips_empty_line():
+    assert format_pip_line("") is None
+    assert format_pip_line("   ") is None
+
+
+def test_keeps_installing_line():
+    result = format_pip_line("Installing collected packages: psutil")
+    assert result == "Installing collected packages: psutil"
+
+
+def test_keeps_successfully_installed():
+    result = format_pip_line("Successfully installed psutil-7.2.2")
+    assert result == "Successfully installed psutil-7.2.2"
+
+
+def test_keeps_error_line():
+    result = format_pip_line("ERROR: Could not find a version that satisfies")
+    assert result == "ERROR: Could not find a version that satisfies"
+
+
+def test_skips_downloading_line():
+    assert format_pip_line("Downloading psutil-7.2.2-cp311-win32.whl (380 kB)") is None
+
+
+def test_strips_trailing_whitespace():
+    result = format_pip_line("Successfully installed psutil-7.2.2   \n")
+    assert result == "Successfully installed psutil-7.2.2"

--- a/tests/test_launcher_window.py
+++ b/tests/test_launcher_window.py
@@ -34,3 +34,11 @@ def test_skips_downloading_line():
 def test_strips_trailing_whitespace():
     result = format_pip_line("Successfully installed psutil-7.2.2   \n")
     assert result == "Successfully installed psutil-7.2.2"
+
+
+def test_skips_using_cached_line():
+    assert format_pip_line("Using cached psutil-7.2.2-cp311-win32.whl") is None
+
+
+def test_skips_obtaining_line():
+    assert format_pip_line("Obtaining file:///some/path") is None


### PR DESCRIPTION
## Summary

- 新增 `gui/launcher_window.py`：`format_pip_line()` 過濾 helper、`UpdateWorker` QThread（即時串流 git pull + pip install 輸出）、`LauncherWindow` widget（進度條 + 滾動 log）
- 新增 `launcher.py`：由 `pythonw.exe` 執行的入口點，完全無黑視窗
- 精簡 `start.bat`：從 60 行縮減至 20 行，只保留 UAC 提權 + PATH 設定 + 呼叫 `pythonw.exe launcher.py`

## 解決的問題

- 黑色 cmd 視窗在 GUI 開啟後持續存在且無法關閉
- 首次安裝時 pip install 完全靜默，使用者誤以為程式卡住

## Test Plan

- [x] 73/73 tests pass
- [ ] 雙擊 `start.bat` — 確認無黑視窗出現
- [ ] 觀察 LauncherWindow 顯示 git pull / pip install 即時輸出
- [ ] 確認更新完成後主 GUI 開啟、LauncherWindow 自動關閉
- [ ] 測試 pip install 失敗情境 — 確認顯示錯誤訊息和 Close 按鈕

🤖 Generated with [Claude Code](https://claude.com/claude-code)