### PR TITLE
fix: ship tthol-reader.exe.config to survive Mark-of-the-Web

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,10 @@ jobs:
           if (-not (Test-Path 'dist\tthol-reader\tthol-reader.exe')) {
             throw "PyInstaller did not produce tthol-reader.exe"
           }
+          # .NET app config (loadFromRemoteSources) so the pythonnet/.NET
+          # backend loads even when the downloaded zip is extracted with
+          # Mark-of-the-Web. Must sit next to the exe, not under _internal.
+          Copy-Item 'tthol-reader.exe.config' 'dist\tthol-reader\' -Force
 
       # ── Stage release contents ─────────────────────────────────
       - name: Stage release tree
@@ -84,6 +88,7 @@ jobs:
           # Sanity check.
           $required = @(
             "$stage\tthol-reader.exe",
+            "$stage\tthol-reader.exe.config",
             "$stage\_internal\webui\dist\index.html",
             "$stage\_internal\knowledge.json",
             "$stage\_internal\tthol.sqlite"

--- a/scripts/build-release-local.ps1
+++ b/scripts/build-release-local.ps1
@@ -47,6 +47,10 @@ Invoke-Exe 'pyinstaller' { & uv run pyinstaller --noconfirm --clean tthol-reader
 if (-not (Test-Path 'dist\tthol-reader\tthol-reader.exe')) {
     throw "PyInstaller did not produce tthol-reader.exe"
 }
+# .NET app config (loadFromRemoteSources) so the pythonnet/.NET backend loads
+# even when the downloaded zip is extracted with Mark-of-the-Web. Must sit next
+# to the exe, not under _internal.
+Copy-Item 'tthol-reader.exe.config' 'dist\tthol-reader\' -Force
 
 Write-Host "[3/5] Stage release tree ..." -ForegroundColor Cyan
 New-Item -ItemType Directory -Path $stage | Out-Null
@@ -57,6 +61,7 @@ if (Test-Path 'README.md') { Copy-Item 'README.md' $stage\ -Force }
 
 $required = @(
     "$stage\tthol-reader.exe",
+    "$stage\tthol-reader.exe.config",
     "$stage\_internal\webui\dist\index.html",
     "$stage\_internal\knowledge.json",
     "$stage\_internal\tthol.sqlite"

--- a/tthol-reader.exe.config
+++ b/tthol-reader.exe.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  .NET app config for the pywebview WinForms/.NET (pythonnet) backend.
+
+  loadFromRemoteSources lets the .NET Framework load managed assemblies that
+  carry the "Mark of the Web" (Zone.Identifier = Internet). Files extracted
+  from a downloaded zip inherit MOTW, and without this the runtime refuses to
+  load _internal\pythonnet\runtime\Python.Runtime.dll, crashing at startup with
+  "Failed to resolve Python.Runtime.Loader.Initialize".
+
+  This file MUST sit next to tthol-reader.exe (the app-domain config), so the
+  build copies it into the onedir root rather than bundling it under _internal.
+-->
+<configuration>
+  <runtime>
+    <loadFromRemoteSources enabled="true" />
+  </runtime>
+</configuration>


### PR DESCRIPTION
## Problem

The downloaded v1.0.0 zip crashed at startup with `Failed to resolve Python.Runtime.Loader.Initialize` **even after** PR #13 pinned pythonnet to 3.0.5. Running the freshly-extracted 3.0.5 build still reproduced it.

## Root cause — Mark-of-the-Web (the real one)

Files extracted from an internet-downloaded zip inherit the **Mark of the Web** (`Zone.Identifier`, Internet zone). .NET Framework's `loadFromRemoteSources` policy then **refuses to load the flagged managed assembly** `_internal\pythonnet\runtime\Python.Runtime.dll`, so pywebview's WinForms backend can't initialize pythonnet.

The pythonnet version was a **red herring** — 3.0.5 and 3.1.0 both fail this way once downloaded. A locally-built bundle (never downloaded → no MOTW) works either way, which is why it passed local testing.

## Reproduced + fixed deterministically

On a byte-identical local build:
- Add `Zone.Identifier=3` to the bundled DLLs → **exact same traceback** (`netfx.py`, `Failed to resolve Loader.Initialize`).
- `Unblock-File` → launches.
- Add MOTW back **+** ship `tthol-reader.exe.config` with `<loadFromRemoteSources enabled="true"/>` next to the exe → **launches with MOTW still on all 19 DLLs**.

## Fix

Ship `tthol-reader.exe.config` (app-domain config for `tthol-reader.exe`) at the **install root**. Both the CI workflow and the local build script copy it next to the exe (it can't go under `_internal`, and PyInstaller `datas` would land it there).

## Verification

- Rebuilt bundle: `tthol-reader.exe.config` at zip root, single `Python.Runtime.dll` (md5 `78ce21de`), no `deps.json`.
- The published **v1.0.0 asset has already been replaced** with this build (27,073,482 bytes), so new downloads work without users having to unblock anything.

Follow-up to #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)