### PR TITLE
feat: systematic buff/debuff status display + compat-layout vitals fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Runtime log (regenerated each run, never committed)
+*.log
+
 # Python-generated files
 __pycache__/
 *.py[oc]
@@ -18,6 +21,10 @@ wheels/
 candidates.json
 pointer_history.json
 pointers.json
+
+# Reverse-engineering / diagnostic scratch scripts (kept locally, not the app)
+_bx_profile.py
+probe_buff.py
 
 # AHK/game scripts
 *.Q

--- a/app.py
+++ b/app.py
@@ -6,16 +6,18 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import logging
 import socket
 import sys
 import threading
 import time
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 import uvicorn
 import webview
 
-from services._paths import bundled
+from services._paths import app_root, bundled
 from services.api import build_app
 from services.auto_click import AutoClickManager
 from services.fake_active import KeepActiveManager
@@ -23,6 +25,31 @@ from services.snapshot_db import SnapshotDB
 from services.worker_manager import WorkerManager
 
 DEV_PORT_FILE = Path(".omc/.dev-port")
+
+
+def _setup_logging() -> None:
+    """Log worker/app events to console + a rotating file next to the exe.
+
+    Without this, worker locate/read failures are invisible (CharSession passes
+    a no-op on_error), which makes connection drops impossible to diagnose.
+    """
+    handlers: list[logging.Handler] = [logging.StreamHandler()]
+    try:
+        handlers.append(
+            RotatingFileHandler(
+                app_root() / "tthol-reader.log",
+                maxBytes=1_000_000,
+                backupCount=2,
+                encoding="utf-8",
+            )
+        )
+    except Exception:
+        pass  # console-only if the install dir is not writable
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        handlers=handlers,
+    )
 
 
 def _pick_port() -> int:
@@ -70,6 +97,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    _setup_logging()
     services = _build_services(args.dev)
     app = build_app(services=services)
 

--- a/auto_detect.py
+++ b/auto_detect.py
@@ -2,22 +2,25 @@
 自動偵測角色結構 - 不需要已知血量值
 利用角色結構的特徵模式掃描記憶體
 """
+
 import pymem
-import ctypes
-import ctypes.wintypes
 import struct
-import json
 import time
 import sys
 
-from reader import MEMORY_BASIC_INFORMATION, MEM_COMMIT, READABLE_PAGES, get_memory_regions, load_knowledge, get_display_fields, read_all_fields, format_status
+from reader import (
+    get_memory_regions,
+    load_knowledge,
+    get_display_fields,
+    read_all_fields,
+    format_status,
+)
 
 
 def scan_for_character(pm):
     """用結構特徵掃描，不需要已知值"""
     regions = get_memory_regions(pm.process_handle)
     knowledge = load_knowledge()
-    fields = knowledge['character_structure']['fields']
 
     total_size = sum(s for _, s in regions)
     scanned = 0
@@ -29,8 +32,8 @@ def scan_for_character(pm):
             # 每 4 bytes 對齊掃描
             for pos in range(0, len(buffer) - 100, 4):
                 # 快速篩選: offset 0 = HP, offset 4 = MaxHP
-                hp = struct.unpack_from('<i', buffer, pos)[0]
-                max_hp = struct.unpack_from('<i', buffer, pos + 4)[0]
+                hp = struct.unpack_from("<i", buffer, pos)[0]
+                max_hp = struct.unpack_from("<i", buffer, pos + 4)[0]
 
                 # HP 和 MaxHP 必須在合理範圍，且 HP <= MaxHP
                 if not (100 <= hp <= 999999 and 100 <= max_hp <= 999999):
@@ -45,13 +48,13 @@ def scan_for_character(pm):
                 # 排除連續遞增數列 (假資料特徵)
                 if max_hp - hp <= 1 and hp > 100:
                     # 再檢查 MP 是不是也在遞增
-                    mp_raw = struct.unpack_from('<i', buffer, pos + 8)[0]
+                    mp_raw = struct.unpack_from("<i", buffer, pos + 8)[0]
                     if abs(mp_raw - max_hp) <= 2:
                         continue
 
                 # MP 檢查: offset 8, 12
-                mp = struct.unpack_from('<i', buffer, pos + 8)[0]
-                max_mp = struct.unpack_from('<i', buffer, pos + 12)[0]
+                mp = struct.unpack_from("<i", buffer, pos + 8)[0]
+                max_mp = struct.unpack_from("<i", buffer, pos + 12)[0]
                 if not (1 <= mp <= 999999 and 1 <= max_mp <= 999999):
                     continue
                 if mp > max_mp:
@@ -64,7 +67,7 @@ def scan_for_character(pm):
                 if pos < 96:  # 確保負偏移不越界
                     continue
 
-                level = struct.unpack_from('<i', buffer, pos - 36)[0]
+                level = struct.unpack_from("<i", buffer, pos - 36)[0]
                 if not (1 <= level <= 999):
                     continue
 
@@ -73,16 +76,16 @@ def scan_for_character(pm):
                     continue
 
                 # 屬性檢查: 外功(-96), 根骨(-88), 技巧(-80)
-                wai_gong = struct.unpack_from('<i', buffer, pos - 96)[0]
-                gen_gu = struct.unpack_from('<i', buffer, pos - 88)[0]
-                ji_qiao = struct.unpack_from('<i', buffer, pos - 80)[0]
+                wai_gong = struct.unpack_from("<i", buffer, pos - 96)[0]
+                gen_gu = struct.unpack_from("<i", buffer, pos - 88)[0]
+                ji_qiao = struct.unpack_from("<i", buffer, pos - 80)[0]
 
                 if not (1 <= wai_gong <= 9999 and 1 <= gen_gu <= 9999 and 1 <= ji_qiao <= 9999):
                     continue
 
                 # 負重: offset 24, 28
-                weight = struct.unpack_from('<i', buffer, pos + 24)[0]
-                max_weight = struct.unpack_from('<i', buffer, pos + 28)[0]
+                weight = struct.unpack_from("<i", buffer, pos + 24)[0]
+                max_weight = struct.unpack_from("<i", buffer, pos + 28)[0]
                 if not (0 <= weight <= 999999 and 1 <= max_weight <= 999999):
                     continue
                 if weight > max_weight:
@@ -90,10 +93,10 @@ def scan_for_character(pm):
 
                 # 戰鬥屬性不應遠大於HP (排除假資料如防禦=31006)
                 # 戰鬥屬性: 物攻(72), 防禦(84), 命中(92), 閃躲(96)
-                atk = struct.unpack_from('<i', buffer, pos + 72)[0]
-                defense = struct.unpack_from('<i', buffer, pos + 84)[0]
-                hit = struct.unpack_from('<i', buffer, pos + 92)[0]
-                dodge = struct.unpack_from('<i', buffer, pos + 96)[0]
+                atk = struct.unpack_from("<i", buffer, pos + 72)[0]
+                defense = struct.unpack_from("<i", buffer, pos + 84)[0]
+                hit = struct.unpack_from("<i", buffer, pos + 92)[0]
+                dodge = struct.unpack_from("<i", buffer, pos + 96)[0]
 
                 if not (1 <= atk <= 99999 and 1 <= defense <= 99999):
                     continue
@@ -110,30 +113,37 @@ def scan_for_character(pm):
                         continue
 
                 # 物攻(72) 和 物攻基礎(76) 應相近
-                atk_base = struct.unpack_from('<i', buffer, pos + 76)[0]
+                atk_base = struct.unpack_from("<i", buffer, pos + 76)[0]
                 if atk_base <= 0 or abs(atk - atk_base) > atk * 0.5:
                     continue
 
                 # 最後檢查: 這些值不能全都很接近 (排除遞增序列)
                 vals = [hp, mp, level, wai_gong, gen_gu, atk, defense]
                 vals_sorted = sorted(vals)
-                max_gap = max(vals_sorted[i+1] - vals_sorted[i] for i in range(len(vals_sorted)-1))
+                max_gap = max(
+                    vals_sorted[i + 1] - vals_sorted[i] for i in range(len(vals_sorted) - 1)
+                )
                 if max_gap < 10:
                     continue
 
                 addr = base + pos
-                candidates.append({
-                    'addr': addr,
-                    'hp': hp, 'max_hp': max_hp,
-                    'mp': mp, 'max_mp': max_mp,
-                    'level': level,
-                    'stats': (wai_gong, gen_gu, ji_qiao),
-                    'atk': atk, 'defense': defense,
-                })
+                candidates.append(
+                    {
+                        "addr": addr,
+                        "hp": hp,
+                        "max_hp": max_hp,
+                        "mp": mp,
+                        "max_mp": max_mp,
+                        "level": level,
+                        "stats": (wai_gong, gen_gu, ji_qiao),
+                        "atk": atk,
+                        "defense": defense,
+                    }
+                )
 
             scanned += size
             pct = scanned / total_size * 100
-            print(f"  掃描進度: {pct:.0f}%  候選: {len(candidates)}", end='\r')
+            print(f"  掃描進度: {pct:.0f}%  候選: {len(candidates)}", end="\r")
         except Exception:
             scanned += size
 
@@ -163,7 +173,7 @@ def main():
     seen = set()
     unique = []
     for c in candidates:
-        key = (c['hp'], c['max_hp'], c['level'])
+        key = (c["hp"], c["max_hp"], c["level"])
         if key not in seen:
             seen.add(key)
             unique.append(c)
@@ -173,14 +183,14 @@ def main():
     display_fields = get_display_fields(knowledge)
 
     for i, c in enumerate(unique):
-        print(f"--- 角色 {i+1} ---")
+        print(f"--- 角色 {i + 1} ---")
         print(f"  地址: 0x{c['addr']:08X}")
-        fields_data = read_all_fields(pm, c['addr'], display_fields)
+        fields_data = read_all_fields(pm, c["addr"], display_fields)
         print(format_status(fields_data))
         print()
 
-    if '--loop' in sys.argv and unique:
-        addr = unique[0]['addr']
+    if "--loop" in sys.argv and unique:
+        addr = unique[0]["addr"]
         print(f"持續監控角色 1 (0x{addr:08X})... Ctrl+C 停止\n")
         try:
             while True:

--- a/find_name.py
+++ b/find_name.py
@@ -9,19 +9,19 @@ Usage:
 Example:
     uv run find_name.py 46277 YourCharName
 """
+
 import sys
 import struct
 import time
 import pymem
-import ctypes
-import ctypes.wintypes
 
 # Re-use infrastructure from reader.py
-sys.path.insert(0, '.')
+sys.path.insert(0, ".")
 from reader import get_memory_regions, locate_character, load_knowledge
 
 
-ENCODINGS = ['big5', 'gbk', 'utf-8']
+ENCODINGS = ["big5", "gbk", "utf-8"]
+
 
 # ============================================================
 # Search memory for a byte pattern
@@ -53,16 +53,16 @@ def read_cstring(pm, addr, max_len=64):
         raw = pm.read_bytes(addr, max_len)
     except Exception:
         return None, None
-    end = raw.find(b'\x00')
+    end = raw.find(b"\x00")
     if end == 0:
         return None, None
     raw = raw[:end] if end != -1 else raw
-    for enc in ['big5', 'gbk', 'utf-8', 'latin-1']:
+    for enc in ["big5", "gbk", "utf-8", "latin-1"]:
         try:
             return raw.decode(enc), enc
         except Exception:
             pass
-    return raw.hex(), 'hex'
+    return raw.hex(), "hex"
 
 
 # ============================================================
@@ -71,14 +71,16 @@ def read_cstring(pm, addr, max_len=64):
 def scan_struct_pointers(pm, hp_addr, scan_range=(-256, 512)):
     """Check every int32 in range from hp_addr; if it looks like a valid
     heap pointer, try to read a string at that address."""
-    print(f"\n[Pointer scan] Scanning offsets {scan_range[0]}..{scan_range[1]} from HP addr for pointers to strings")
+    print(
+        f"\n[Pointer scan] Scanning offsets {scan_range[0]}..{scan_range[1]} from HP addr for pointers to strings"
+    )
     start = scan_range[0]
     end = scan_range[1]
     found = []
     for off in range(start, end, 4):
         try:
             raw = pm.read_bytes(hp_addr + off, 4)
-            ptr = struct.unpack('<I', raw)[0]
+            ptr = struct.unpack("<I", raw)[0]
         except Exception:
             continue
         # Valid 32-bit heap pointer range
@@ -88,7 +90,9 @@ def scan_struct_pointers(pm, hp_addr, scan_range=(-256, 512)):
         text, enc = read_cstring(pm, ptr)
         if text and len(text) >= 2 and len(text) <= 32:
             # Filter: at least one printable non-ASCII char or purely ASCII name
-            printable = all(32 <= b < 127 or b >= 0x81 for b in text.encode('latin-1', errors='replace'))
+            printable = all(
+                32 <= b < 127 or b >= 0x81 for b in text.encode("latin-1", errors="replace")
+            )
             if printable:
                 print(f"  HP+{off:+d}  ptr=0x{ptr:08X}  -> '{text}'  [{enc}]")
                 found.append((off, ptr, text, enc))
@@ -127,7 +131,7 @@ def dump_strings_near_hp(pm, hp_addr, before=512, after=1024):
                     break
             run = raw[i:j]
             if len(run) >= 4:
-                for enc in ['big5', 'gbk']:
+                for enc in ["big5", "gbk"]:
                     try:
                         text = run.decode(enc)
                         offset_from_hp = (hp_addr - before + i) - hp_addr
@@ -144,7 +148,7 @@ def dump_strings_near_hp(pm, hp_addr, before=512, after=1024):
 # Main
 # ============================================================
 def main():
-    sys.stdout.reconfigure(encoding='utf-8')
+    sys.stdout.reconfigure(encoding="utf-8")
 
     if len(sys.argv) < 3:
         print("Usage: uv run find_name.py <current_hp> <character_name>")
@@ -201,5 +205,5 @@ def main():
     print("\nDone.")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/knowledge.json
+++ b/knowledge.json
@@ -45,6 +45,47 @@
       "420": { "name": "Y座標", "type": "int32", "sample_value": 127 }
     }
   },
+  "buff_structure": {
+    "description": "角色身上的 active buff 列表。count + 緊湊陣列，存的是 status `group` 不是 status id。",
+    "note": "陣列會 compact；只有前 <count> 個 slot 有效，後面可能殘留舊值。確切等級/剩餘時間不在此持久儲存。",
+    "kind": "buff",
+    "count_offset": 648,
+    "array_offset": 652,
+    "slot_size": 4,
+    "max_slots": 32,
+    "value_type": "int32 (status.group)",
+    "status_db": {
+      "file": "tthol.sqlite",
+      "table": "status",
+      "group_column": "group",
+      "name_column": "name"
+    },
+    "verified_sample": {
+      "anchor_groups": { "31": "血契(刺槐血契)", "32": "靈契(纏絲靈契)", "51": "護體(冰霜烈炎盾)" },
+      "note": "施放冰霜烈炎盾時 count 由 2->3、array 追加 51；HP+0x4(maxHP)、HP+0x54(防禦) 同步被 buff 改動"
+    },
+    "scope_note": "此陣列只涵蓋『契/盾/陣/符』類正面自我 buff（高 group 31/32/51/52）。負面 debuff 見 debuff_structure (HP+0x4C4)。默念純屬性 buff（如冰心靈訣 group 2）兩個陣列都不進，只在繪圖層出現，無法穩定偵測。"
+  },
+  "debuff_structure": {
+    "description": "角色身上的負面狀態 (debuff) 列表，例如中毒。與 buff_structure 機制完全相同：count + 緊湊 status.group 陣列。",
+    "note": "陣列會 compact、count-gated；count 之後的 slot 殘留舊值（觀察到 count 1->0 時 slot 仍殘留 19）。確切等級/剩餘時間不在此持久儲存。",
+    "kind": "debuff",
+    "count_offset": 1220,
+    "array_offset": 1224,
+    "slot_size": 4,
+    "max_slots": 32,
+    "value_type": "int32 (status.group)",
+    "status_db": {
+      "file": "tthol.sqlite",
+      "table": "status",
+      "group_column": "group",
+      "name_column": "name"
+    },
+    "verified_sample": {
+      "anchor_groups": { "19": "中毒" },
+      "note": "中毒生效時 HP+0x4C4 count=1、array=[19]；實時觀察到中毒過期瞬間 count 由 1->0（slot 殘留 19，被 count gate 濾掉），與 HP+0x288 同機制。DB 中『中毒』分屬 group 19/70/71。"
+    }
+  },
   "inventory_structure": {
     "description": "背包物品陣列，每槽固定 2272 bytes (0x8E0)",
     "locate_method": "掃描已知物品ID，匹配特徵模式: [8 bytes zeros][item_id][pointer][24+ bytes zeros]",

--- a/reader.py
+++ b/reader.py
@@ -462,12 +462,26 @@ def read_character_name(pm, hp_addr):
         return ""
 
 
-def read_all_fields(pm, hp_addr, display_fields):
-    """Read all known integer fields."""
+# In the compat (4-byte-shifted) layout the current/max HP and MP pairs are
+# stored swapped relative to the normal layout (see verify_structure_shifted):
+#   struct_base+0 = max_HP, +4 = current_HP, +8 = max_MP, +12 = current_MP.
+# Remap exactly those four offsets so each field keeps its correct meaning;
+# every other field shares the normal-layout offset.
+_COMPAT_OFFSET_SWAP = {0: 4, 4: 0, 8: 12, 12: 8}
+
+
+def read_all_fields(pm, hp_addr, display_fields, compat_mode=False):
+    """Read all known integer fields.
+
+    When compat_mode is True the struct uses the 4-byte-shifted layout, so the
+    HP/MP current/max offsets (0/4 and 8/12) are remapped to keep 血量/最大血量/
+    真氣/最大真氣 correct. All other fields share the normal-layout offsets.
+    """
     result = []
     for offset, name in display_fields:
+        phys = _COMPAT_OFFSET_SWAP.get(offset, offset) if compat_mode else offset
         try:
-            value = pm.read_int(hp_addr + offset)
+            value = pm.read_int(hp_addr + phys)
             result.append((name, value))
         except Exception:
             result.append((name, "???"))
@@ -547,6 +561,119 @@ def load_item_db():
     items = {row[0]: row[1] for row in cur.fetchall()}
     conn.close()
     return items
+
+
+# ============================================================
+# Active-buff list (status-group array inside the char struct)
+# Defaults; overridable via knowledge.json "buff_structure".
+# ============================================================
+BUFF_COUNT_OFFSET = 0x288  # int32: number of active buffs
+BUFF_ARRAY_OFFSET = 0x28C  # int32[]: compacting array of status `group` ids
+BUFF_MAX_SLOTS = 32
+
+
+def read_status_array(pm, hp_addr, count_off, array_off, max_slots):
+    """Read one count+group status array relative to the HP base.
+
+    Layout: an int32 count at count_off, then a compacting array of int32
+    status-group ids at array_off. Only the first <count> slots are valid;
+    trailing slots may hold stale values. Returns a list of group ids (ints),
+    or [] on any read failure.
+    """
+    try:
+        count = pm.read_int(hp_addr + count_off)
+    except Exception:
+        return []
+    if count <= 0 or count > max_slots:
+        return []
+    groups = []
+    for i in range(count):
+        try:
+            g = pm.read_int(hp_addr + array_off + i * 4)
+        except Exception:
+            break
+        if 0 < g < 100000:  # plausible group id; skip stale/garbage
+            groups.append(g)
+    return groups
+
+
+def read_active_buffs(pm, hp_addr, knowledge=None):
+    """Read positive-buff status groups (HP+0x288). Kept for backward
+    compatibility; new code should prefer read_active_statuses().
+    """
+    count_off, array_off, max_slots = BUFF_COUNT_OFFSET, BUFF_ARRAY_OFFSET, BUFF_MAX_SLOTS
+    if knowledge:
+        bs = knowledge.get("buff_structure")
+        if bs:
+            count_off = bs.get("count_offset", count_off)
+            array_off = bs.get("array_offset", array_off)
+            max_slots = bs.get("max_slots", max_slots)
+    return read_status_array(pm, hp_addr, count_off, array_off, max_slots)
+
+
+def read_active_statuses(pm, hp_addr, knowledge=None):
+    """Read every status array declared in knowledge.json.
+
+    A status array is any structure carrying both count_offset and array_offset
+    whose value_type names status groups (buff_structure, debuff_structure, …).
+    Returns a list of (group, kind) tuples, where `kind` comes from the
+    structure's "kind" field (defaulting to the key minus "_structure").
+
+    Config-driven: to cover a newly reverse-engineered status category, add its
+    verified offsets + a "kind" to knowledge.json — no code change needed.
+    """
+    if not knowledge:
+        return [
+            (g, "buff")
+            for g in read_status_array(
+                pm, hp_addr, BUFF_COUNT_OFFSET, BUFF_ARRAY_OFFSET, BUFF_MAX_SLOTS
+            )
+        ]
+    out = []
+    for key, st in knowledge.items():
+        if not isinstance(st, dict) or "count_offset" not in st or "array_offset" not in st:
+            continue
+        if "status" not in str(st.get("value_type", "")).lower():
+            continue  # skip inventory/warehouse slot arrays
+        kind = st.get("kind") or key.replace("_structure", "")
+        for g in read_status_array(
+            pm,
+            hp_addr,
+            st.get("count_offset", BUFF_COUNT_OFFSET),
+            st.get("array_offset", BUFF_ARRAY_OFFSET),
+            st.get("max_slots", BUFF_MAX_SLOTS),
+        ):
+            out.append((g, kind))
+    return out
+
+
+def load_status_db():
+    """Map status `group` id -> representative buff name from tthol.sqlite.
+
+    A group's statuses share a display name across levels (護體/血契/靈契...),
+    so the first row per group (lowest `order`) is a good representative.
+    """
+    db_path = bundled("tthol.sqlite")
+    if not db_path.exists():
+        return {}
+    conn = None
+    try:
+        conn = sqlite3.connect(str(db_path))
+        conn.text_factory = lambda b: b.decode("utf-8", errors="replace")
+        cur = conn.cursor()
+        cur.execute('SELECT "group", name FROM status ORDER BY "group", "order"')
+        out = {}
+        for group_id, name in cur.fetchall():
+            if group_id not in out:
+                out[group_id] = name
+        return out
+    except Exception:
+        return {}
+    finally:
+        # sqlite's `with` only manages the transaction, not the handle, so close
+        # explicitly here to avoid leaking the connection on the error path.
+        if conn is not None:
+            conn.close()
 
 
 def locate_inventory(pm):

--- a/reader.py
+++ b/reader.py
@@ -309,7 +309,7 @@ def verify_structure(pm, hp_addr, fields, skip_seq_check=False):
                 val = pm.read_int(hp_addr + offset)
                 if not (min_val <= val <= max_val):
                     penalties += 1
-            except:
+            except Exception:
                 penalties += 1
 
         # Check coordinates reasonableness
@@ -318,7 +318,7 @@ def verify_structure(pm, hp_addr, fields, skip_seq_check=False):
                 coord = pm.read_int(hp_addr + offset)
                 if not (-1 <= coord <= 10000):
                     penalties += 1
-            except:
+            except Exception:
                 penalties += 1
 
         # Detect sequential number pattern (false positive indicator)
@@ -327,7 +327,7 @@ def verify_structure(pm, hp_addr, fields, skip_seq_check=False):
             diffs = [abs(vals[i + 1] - vals[i]) for i in range(len(vals) - 1)]
             if sum(1 for d in diffs if d < 10) >= 4:
                 penalties += 3
-        except:
+        except Exception:
             pass
 
         # Apply penalties
@@ -385,7 +385,7 @@ def verify_structure_shifted(pm, struct_base, fields):
                 val = pm.read_int(struct_base + offset)
                 if not (min_val <= val <= max_val):
                     penalties += 1
-            except:
+            except Exception:
                 penalties += 1
 
         for offset in [416, 420]:
@@ -393,7 +393,7 @@ def verify_structure_shifted(pm, struct_base, fields):
                 coord = pm.read_int(struct_base + offset)
                 if not (-1 <= coord <= 10000):
                     penalties += 1
-            except:
+            except Exception:
                 penalties += 1
 
         score -= penalties * 0.1
@@ -448,9 +448,9 @@ def locate_map_name(pm, valid_names: set[str] | None = None):
             if str_start + 4 >= len(data):
                 continue
 
-            h = data[str_start]
-            l = data[str_start + 1]
-            if not (0xA1 <= h <= 0xF9 and 0x40 <= l <= 0xFE):
+            hi = data[str_start]
+            lo = data[str_start + 1]
+            if not (0xA1 <= hi <= 0xF9 and 0x40 <= lo <= 0xFE):
                 continue
 
             null_pos = data.find(b"\x00", str_start, str_start + 17)

--- a/reader.py
+++ b/reader.py
@@ -147,6 +147,47 @@ def resolve_filters(filters, knowledge):
 # ============================================================
 # 定位角色結構
 # ============================================================
+# Real character structs live on the heap; static/module data sits below this
+# floor. A candidate below it is a struct-shaped false positive: a second client
+# that had not logged in once locked dead static memory (0x00A3BE14) that scored
+# a perfect 1.0 and so never re-located. 32-bit heap spans up to 0x7FFFFFFF.
+HEAP_MIN_ADDR = 0x10000000
+
+# Character name: null-terminated Big5 string at NAME_OFFSET from the HP base.
+NAME_OFFSET = -228
+NAME_MAX_BYTES = 32
+
+
+def _has_valid_character_name(pm, struct_base):
+    """True when a Big5 character name sits at NAME_OFFSET.
+
+    A genuine character always has a name there; struct-shaped garbage (static
+    data, freed heap) does not. Used as a hard constraint in verify_structure to
+    reject false positives that satisfy the numeric checks but are not real
+    characters. Requires the first character to be a valid Big5 double-byte
+    (names start with a CJK glyph) and the whole name to decode as Big5.
+    """
+    try:
+        raw = pm.read_bytes(struct_base + NAME_OFFSET, NAME_MAX_BYTES)
+    except Exception:
+        return False
+    # A real name is null-terminated within the 32-byte field (padded after).
+    # Garbage heap with no terminator in the window is not a character name.
+    end = raw.find(b"\x00")
+    if end < 2:
+        return False
+    raw = raw[:end]
+    if len(raw) % 2 != 0:  # Big5 names are whole double-byte characters
+        return False
+    if not (0xA1 <= raw[0] <= 0xF9 and 0x40 <= raw[1] <= 0xFE):
+        return False
+    try:
+        raw.decode("big5")
+    except Exception:
+        return False
+    return True
+
+
 def locate_character(pm, hp_value, knowledge, offset_filters=None, compat_mode=False):
     """Scan memory for HP value, return best candidate with highest score.
 
@@ -172,7 +213,7 @@ def locate_character(pm, hp_value, knowledge, offset_filters=None, compat_mode=F
                 pos = buffer.find(target_bytes, offset)
                 if pos == -1:
                     break
-                if pos % 4 == 0:
+                if pos % 4 == 0 and base + pos >= HEAP_MIN_ADDR:
                     addr = base + pos
                     score = verify_structure(pm, addr, fields)
                     if score >= 0.8:
@@ -202,7 +243,7 @@ def locate_character(pm, hp_value, knowledge, offset_filters=None, compat_mode=F
                     if pos == -1:
                         break
                     # hp_value is at addr = struct_base + 4 (shifted by 4 bytes)
-                    if pos % 4 == 0 and pos >= 4:
+                    if pos % 4 == 0 and pos >= 4 and base + pos - 4 >= HEAP_MIN_ADDR:
                         struct_base = base + pos - 4
                         score = verify_structure_shifted(pm, struct_base, fields)
                         if score >= 0.8:
@@ -249,6 +290,9 @@ def verify_structure(pm, hp_addr, fields, skip_seq_check=False):
         if not (0 <= weight <= weight_max <= 999999):
             return 0.0
         if not (1 <= level <= 200):
+            return 0.0
+        # A real character has a Big5 name here; struct-shaped garbage does not.
+        if not _has_valid_character_name(pm, hp_addr):
             return 0.0
 
         score = 1.0
@@ -323,6 +367,9 @@ def verify_structure_shifted(pm, struct_base, fields):
             return 0.0
         if not (1 <= level <= 200):
             return 0.0
+        # A real character has a Big5 name here; struct-shaped garbage does not.
+        if not _has_valid_character_name(pm, struct_base):
+            return 0.0
 
         score = 1.0
         penalties = 0
@@ -359,10 +406,6 @@ def verify_structure_shifted(pm, struct_base, fields):
 # ============================================================
 # 顯示角色狀態
 # ============================================================
-NAME_OFFSET = -228
-NAME_MAX_BYTES = 32
-
-
 def locate_map_name(pm, valid_names: set[str] | None = None):
     """Scan heap for the current map name string.
 

--- a/services/api_types.py
+++ b/services/api_types.py
@@ -75,6 +75,20 @@ class Item(_Base):
     source: Literal["inventory", "warehouse"]
 
 
+# ---- Buffs (active status effects) --------------------------------------
+
+
+class BuffInfo(_Base):
+    """One active status on a character. The game stores the status `group`
+    (not the exact status id), so `name` is the representative status name
+    for that group (e.g. 護體 / 血契 / 靈契 / 中毒). `kind` distinguishes the
+    source array: positive self-buffs (HP+0x288) vs debuffs (HP+0x4C4)."""
+
+    group: int
+    name: str
+    kind: Literal["buff", "debuff"] = "buff"
+
+
 # ---- Character views -----------------------------------------------------
 
 
@@ -99,6 +113,7 @@ class CharacterRow(_Base):
     vitals: Vitals
     position: Position
     autoclick: AutoClickStatus
+    buffs: list[BuffInfo] = []
 
 
 class CharacterDetail(_Base):
@@ -110,6 +125,7 @@ class CharacterDetail(_Base):
     vitals: Vitals
     position: Position
     autoclick: AutoClickStatus
+    buffs: list[BuffInfo] = []
     inventory: list[Item] | None = None
     warehouse: list[Item] | None = None
 

--- a/services/char_session.py
+++ b/services/char_session.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 from services.api_types import (
     AutoClickStatus,
+    BuffInfo,
     CharacterDetail,
     CharacterRow,
     CharacterStats,
@@ -57,6 +58,7 @@ class CharSession:
         self._latest_stats: dict[str, int] = {}
         self._latest_inv: list[Item] = []
         self._latest_wh: list[Item] = []
+        self._latest_buffs: list[BuffInfo] = []
         self._inv_seq: int = 0
         self._wh_seq: int = 0
         self._lock = threading.Lock()
@@ -67,6 +69,7 @@ class CharSession:
             on_inventory=self._on_inv,
             on_warehouse=self._on_wh,
             on_error=lambda _msg: None,
+            on_buffs=self._on_buffs,
         )
 
     def start(self, hp: int | None = None, compat_mode: bool = False) -> None:
@@ -113,6 +116,7 @@ class CharSession:
                 ),
                 position=Position(map_name=s.get("map_name"), x=s.get("x", 0), y=s.get("y", 0)),
                 autoclick=AutoClickStatus(running=False),
+                buffs=list(self._latest_buffs),
             )
 
     def detail(self) -> CharacterDetail:
@@ -149,6 +153,7 @@ class CharSession:
                 ),
                 position=Position(map_name=s.get("map_name"), x=s.get("x", 0), y=s.get("y", 0)),
                 autoclick=AutoClickStatus(running=False),
+                buffs=list(self._latest_buffs),
                 inventory=self._latest_inv or None,
                 warehouse=self._latest_wh or None,
             )
@@ -170,6 +175,10 @@ class CharSession:
             name = translated.get("name")
             if isinstance(name, str) and name:
                 self.name = name
+
+    def _on_buffs(self, items: list[tuple[int, str, str]]) -> None:
+        with self._lock:
+            self._latest_buffs = [BuffInfo(group=g, name=n, kind=k) for g, n, k in items]
 
     def _on_inv(self, items: list[tuple[int, int, str]]) -> None:
         with self._lock:

--- a/services/worker.py
+++ b/services/worker.py
@@ -11,6 +11,7 @@ States:
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 import threading
@@ -25,9 +26,11 @@ from reader import (
     get_display_fields,
     load_item_db,
     load_knowledge,
+    load_status_db,
     locate_character,
     locate_inventory,
     locate_map_name,
+    read_active_statuses,
     read_all_fields,
     read_character_name,
     read_hp_from_player_chain,
@@ -49,6 +52,8 @@ LOCATE_RETRY_INTERVAL = 3.0
 LOCATE_MAX_RETRIES = 10
 MAP_RESCAN_EVERY = 5  # locate_map_name walks the heap; cache between polls
 
+log = logging.getLogger("tthol.worker")
+
 
 class ReaderWorker(threading.Thread):
     """Per-PID worker thread. Calls callbacks instead of emitting Qt signals."""
@@ -61,6 +66,7 @@ class ReaderWorker(threading.Thread):
         on_inventory: Callable[[list[tuple[int, int, str]]], None],
         on_warehouse: Callable[[list[tuple[int, int, str]]], None],
         on_error: Callable[[str], None],
+        on_buffs: Callable[[list[tuple[int, str, str]]], None] | None = None,
     ) -> None:
         super().__init__(daemon=True)
         self._pid = pid
@@ -69,6 +75,7 @@ class ReaderWorker(threading.Thread):
         self._cb_inventory = on_inventory
         self._cb_warehouse = on_warehouse
         self._cb_error = on_error
+        self._cb_buffs = on_buffs or (lambda _b: None)
         self._hp_value: int | None = None
         self._offset_filters = None
         self._compat_mode = False
@@ -79,6 +86,7 @@ class ReaderWorker(threading.Thread):
         self._knowledge = load_knowledge()
         self._display_fields = get_display_fields(self._knowledge)
         self._item_db = load_item_db()
+        self._status_db = load_status_db()
         try:
             self._stage_names = all_stage_names()
         except Exception:
@@ -124,22 +132,13 @@ class ReaderWorker(threading.Thread):
             self._cb_state("DISCONNECTED")
             return
 
-        hp_addr = None
-        for attempt in range(LOCATE_MAX_RETRIES + 1):
-            hp_addr = self._locate(pm, silent=True)
-            if hp_addr is not None:
-                break
-            if self._stop_event.is_set():
-                self._cb_state("DISCONNECTED")
-                return
-            if attempt == 0:
-                self._cb_state("WAITING")
-            self._stop_event.wait(LOCATE_RETRY_INTERVAL)
-
+        hp_addr = self._locate_with_retries(pm, "WAITING")
         if hp_addr is None:
+            log.warning("initial locate failed after %d retries; disconnecting", LOCATE_MAX_RETRIES)
             self._cb_state("DISCONNECTED")
             return
 
+        log.info("located character at 0x%08X (compat=%s)", hp_addr, self._compat_mode)
         self._cb_state("LOCATED")
         char_name = read_character_name(pm, hp_addr)
         failure_count = 0
@@ -157,7 +156,7 @@ class ReaderWorker(threading.Thread):
                 self._do_warehouse_scan(pm)
 
             try:
-                fields = read_all_fields(pm, hp_addr, self._display_fields)
+                fields = read_all_fields(pm, hp_addr, self._display_fields, self._compat_mode)
                 if self._compat_mode:
                     score = verify_structure_shifted(pm, hp_addr, struct_fields)
                 else:
@@ -166,15 +165,19 @@ class ReaderWorker(threading.Thread):
                 if score < 0.8:
                     failure_count += 1
                     if failure_count >= FAILURE_THRESHOLD:
+                        log.info(
+                            "lost lock (validation score < 0.8 x%d); re-locating", FAILURE_THRESHOLD
+                        )
                         self._cb_state("READ_ERROR")
-                        self._cb_state("RESCANNING")
-                        hp_addr = self._locate(pm)
+                        hp_addr = self._locate_with_retries(pm, "RESCANNING")
                         if hp_addr is None:
+                            log.warning("re-locate failed after retries; disconnecting")
                             self._cb_error(
-                                "Character not found -- please enter the new character's HP value"
+                                "Character not found -- press 重偵 or enter the HP value"
                             )
                             self._cb_state("DISCONNECTED")
                             return
+                        log.info("re-acquired at 0x%08X (compat=%s)", hp_addr, self._compat_mode)
                         self._cb_state("LOCATED")
                         char_name = read_character_name(pm, hp_addr)
                         failure_count = 0
@@ -186,23 +189,28 @@ class ReaderWorker(threading.Thread):
                         map_name = locate_map_name(pm, valid_names=self._stage_names)
                     map_tick += 1
                     self._cb_stats([("角色名稱", char_name), ("地圖名稱", map_name)] + fields)
+                    statuses = read_active_statuses(pm, hp_addr, self._knowledge)
+                    self._cb_buffs(
+                        [(g, self._status_db.get(g, f"group {g}"), kind) for g, kind in statuses]
+                    )
 
-            except Exception:
+            except Exception as exc:
                 failure_count += 1
                 if failure_count >= FAILURE_THRESHOLD:
+                    log.info("read exception (%s); reconnecting + re-locating", exc)
                     self._cb_state("READ_ERROR")
                     pm = self._connect_process()
                     if pm is None:
+                        log.warning("process gone; disconnecting")
                         self._cb_state("DISCONNECTED")
                         return
-                    self._cb_state("RESCANNING")
-                    hp_addr = self._locate(pm)
+                    hp_addr = self._locate_with_retries(pm, "RESCANNING")
                     if hp_addr is None:
-                        self._cb_error(
-                            "Character not found -- please enter the new character's HP value"
-                        )
+                        log.warning("re-locate failed after retries; disconnecting")
+                        self._cb_error("Character not found -- press 重偵 or enter the HP value")
                         self._cb_state("DISCONNECTED")
                         return
+                    log.info("re-acquired at 0x%08X (compat=%s)", hp_addr, self._compat_mode)
                     self._cb_state("LOCATED")
                     char_name = read_character_name(pm, hp_addr)
                     failure_count = 0
@@ -224,20 +232,52 @@ class ReaderWorker(threading.Thread):
             self._cb_error(f"Cannot connect to PID {self._pid}: {e}")
             return None
 
+    def _locate_with_retries(self, pm, waiting_state: str):
+        """Locate with bounded retries (~LOCATE_MAX_RETRIES x LOCATE_RETRY_INTERVAL).
+
+        The character struct lives on the heap and is reallocated on events like
+        map changes, so its address moves; a single locate attempt can land in
+        the brief window where the old block is already freed (0xCDCDCDCD) and
+        the new one is not yet valid. Retrying a bounded number of times lets a
+        moved struct self-heal, without spinning forever for a genuinely
+        logged-out character (recovery past the bound is via the UI 重偵 button).
+        Emits `waiting_state` after the first miss. Returns the address or None.
+        """
+        for attempt in range(LOCATE_MAX_RETRIES + 1):
+            addr = self._locate(pm, silent=True)
+            if addr is not None:
+                return addr
+            if self._stop_event.is_set():
+                return None
+            if attempt == 0:
+                self._cb_state(waiting_state)
+            self._stop_event.wait(LOCATE_RETRY_INTERVAL)
+        return None
+
     def _locate(self, pm, silent: bool = False):
+        # Try both the normal and the 4-byte-shifted (compat) layout, preferring
+        # whichever is currently selected. Some characters only match in compat
+        # layout (observed when HP is buffed so current HP > base max HP), so we
+        # auto-fall back instead of staying unlocated. Whichever layout matches
+        # is remembered in self._compat_mode so the polling loop validates with
+        # the matching verifier.
+        modes = (self._compat_mode, not self._compat_mode)
+
         # Primary: read HP from stable pointer chain, then scan for flat struct
         try:
             hp_from_chain = read_hp_from_player_chain(pm)
             if hp_from_chain is not None:
-                addr = locate_character(
-                    pm,
-                    hp_from_chain,
-                    self._knowledge,
-                    self._offset_filters,
-                    compat_mode=self._compat_mode,
-                )
-                if addr is not None:
-                    return addr
+                for compat in modes:
+                    addr = locate_character(
+                        pm,
+                        hp_from_chain,
+                        self._knowledge,
+                        self._offset_filters,
+                        compat_mode=compat,
+                    )
+                    if addr is not None:
+                        self._compat_mode = compat
+                        return addr
         except Exception:
             pass
 
@@ -249,13 +289,18 @@ class ReaderWorker(threading.Thread):
                 )
             return None
         try:
-            return locate_character(
-                pm,
-                self._hp_value,
-                self._knowledge,
-                self._offset_filters,
-                compat_mode=self._compat_mode,
-            )
+            for compat in modes:
+                addr = locate_character(
+                    pm,
+                    self._hp_value,
+                    self._knowledge,
+                    self._offset_filters,
+                    compat_mode=compat,
+                )
+                if addr is not None:
+                    self._compat_mode = compat
+                    return addr
+            return None
         except Exception as e:
             if not silent:
                 self._cb_error(f"Scan failed: {e}")

--- a/tests/test_read_all_fields_compat.py
+++ b/tests/test_read_all_fields_compat.py
@@ -1,0 +1,63 @@
+"""read_all_fields compat-layout (4-byte-shifted) remap.
+
+In compat layout the game stores the HP/MP current/max pairs swapped
+(struct_base+0 = max_HP, +4 = current_HP, +8 = max_MP, +12 = current_MP).
+read_all_fields must remap those offsets when compat_mode is True so the
+published vitals keep their correct meaning; the worker auto-selects compat
+layout for some characters, so this path is reachable at runtime.
+"""
+
+from reader import read_all_fields
+
+# Field names are data from knowledge.json (Chinese by design); comments stay
+# English per project convention.
+DISPLAY_FIELDS = [
+    (0, "血量"),  # current HP
+    (4, "最大血量"),  # max HP
+    (8, "真氣"),  # current MP
+    (12, "最大真氣"),  # max MP
+    (-36, "等級"),  # level (unaffected by compat shift)
+]
+
+
+class FakePm:
+    """Minimal pymem stand-in: read_int reads from an addr->value map."""
+
+    def __init__(self, mem):
+        self._mem = mem
+
+    def read_int(self, addr):
+        return self._mem[addr]
+
+
+def test_normal_layout_reads_straight_offsets():
+    mem = {0: 100, 4: 500, 8: 30, 12: 200, -36: 90}
+    result = dict(read_all_fields(FakePm(mem), 0, DISPLAY_FIELDS, compat_mode=False))
+    assert result == {"血量": 100, "最大血量": 500, "真氣": 30, "最大真氣": 200, "等級": 90}
+
+
+def test_compat_layout_remaps_hp_mp_pairs():
+    # Compat storage: max_HP@0, current_HP@4, max_MP@8, current_MP@12.
+    mem = {0: 500, 4: 100, 8: 200, 12: 30, -36: 90}
+    result = dict(read_all_fields(FakePm(mem), 0, DISPLAY_FIELDS, compat_mode=True))
+    # Despite the swapped storage, each field keeps its correct meaning.
+    assert result == {"血量": 100, "最大血量": 500, "真氣": 30, "最大真氣": 200, "等級": 90}
+
+
+def test_compat_buffer_without_flag_is_swapped():
+    # Regression guard: reading a compat-laid-out struct in normal mode yields
+    # swapped HP/MP — the exact defect the compat_mode flag fixes.
+    mem = {0: 500, 4: 100, 8: 200, 12: 30, -36: 90}
+    result = dict(read_all_fields(FakePm(mem), 0, DISPLAY_FIELDS, compat_mode=False))
+    assert result["血量"] == 500  # max leaks into current -> wrong
+    assert result["最大血量"] == 100
+    assert result["真氣"] == 200
+    assert result["最大真氣"] == 30
+
+
+def test_unmapped_field_read_error_is_tolerated():
+    # A field whose offset is missing from memory raises KeyError inside read_int;
+    # read_all_fields must degrade to "???" rather than propagate.
+    mem = {0: 100, 4: 500, 8: 30, 12: 200}  # no -36 (等級)
+    result = dict(read_all_fields(FakePm(mem), 0, DISPLAY_FIELDS, compat_mode=False))
+    assert result["等級"] == "???"

--- a/tests/test_reader_filter.py
+++ b/tests/test_reader_filter.py
@@ -1,4 +1,9 @@
+import struct
+from unittest.mock import MagicMock, patch
+
 import pytest
+
+from reader import HEAP_MIN_ADDR
 
 
 def test_parse_filters_returns_dict():
@@ -60,8 +65,34 @@ def test_resolve_filters_unknown_name_raises():
         resolve_filters({"未知": 1}, knowledge)
 
 
-from unittest.mock import MagicMock, patch
-import struct
+# Candidate addresses must sit on the heap (>= HEAP_MIN_ADDR); real character
+# structs never live in low static/module memory. Tests place the buffer at a
+# heap base so the address-range guard does not reject the synthetic candidate.
+_HEAP_BASE = HEAP_MIN_ADDR + 0x10000000
+_POS = 228  # 4-byte aligned, leaves room for negative offsets down to -228
+
+
+def _struct_buf(level=99):
+    buf = bytearray(1024)
+    struct.pack_into("<i", buf, _POS, 287)  # offset 0: hp
+    struct.pack_into("<i", buf, _POS + 4, 287)  # offset 4: max_hp
+    struct.pack_into("<i", buf, _POS + 8, 100)  # offset 8: mp
+    struct.pack_into("<i", buf, _POS + 12, 100)  # offset 12: max_mp
+    struct.pack_into("<i", buf, _POS + 24, 0)  # offset 24: weight
+    struct.pack_into("<i", buf, _POS + 28, 1000)  # offset 28: max_weight
+    struct.pack_into("<i", buf, _POS - 36, level)  # offset -36: level
+    return buf
+
+
+def _fake_pm(buf, base=_HEAP_BASE, read_int=None):
+    pm = MagicMock()
+    pm.process_handle = MagicMock()
+    pm.read_bytes.return_value = bytes(buf)
+    # Tests address memory absolutely (base + index); map back to buffer index.
+    pm.read_int.side_effect = read_int or (
+        lambda addr: struct.unpack_from("<i", buf, addr - base)[0]
+    )
+    return pm
 
 
 def test_locate_character_respects_filters():
@@ -69,26 +100,10 @@ def test_locate_character_respects_filters():
     from reader import locate_character, load_knowledge
 
     knowledge = load_knowledge()
-
-    hp = 287
-    # Build a buffer with hp at pos=228 (room for negative offsets down to -228)
-    buf = bytearray(1024)
-    pos = 228  # 4-byte aligned
-    struct.pack_into("<i", buf, pos, hp)  # offset 0: hp
-    struct.pack_into("<i", buf, pos + 4, hp)  # offset 4: max_hp
-    struct.pack_into("<i", buf, pos + 8, 100)  # offset 8: mp
-    struct.pack_into("<i", buf, pos + 12, 100)  # offset 12: max_mp
-    struct.pack_into("<i", buf, pos + 24, 0)  # offset 24: weight
-    struct.pack_into("<i", buf, pos + 28, 1000)  # offset 28: max_weight
-    struct.pack_into("<i", buf, pos - 36, 99)  # offset -36: level=99 (NOT 7)
-
-    pm = MagicMock()
-    pm.process_handle = MagicMock()
-    with patch("reader.get_memory_regions", return_value=[(0, len(buf))]):
+    buf = _struct_buf()
+    with patch("reader.get_memory_regions", return_value=[(_HEAP_BASE, len(buf))]):
         with patch("reader.verify_structure", return_value=1.0):
-            pm.read_bytes.return_value = bytes(buf)
-            pm.read_int.side_effect = lambda addr: struct.unpack_from("<i", buf, addr)[0]
-            result = locate_character(pm, hp, knowledge, offset_filters={-36: 7})
+            result = locate_character(_fake_pm(buf), 287, knowledge, offset_filters={-36: 7})
 
     assert result is None  # filtered out because level(99) != 7
 
@@ -98,27 +113,12 @@ def test_locate_character_no_filters_keeps_candidate():
     from reader import locate_character, load_knowledge
 
     knowledge = load_knowledge()
-
-    hp = 287
-    buf = bytearray(1024)
-    pos = 228
-    struct.pack_into("<i", buf, pos, hp)
-    struct.pack_into("<i", buf, pos + 4, hp)
-    struct.pack_into("<i", buf, pos + 8, 100)
-    struct.pack_into("<i", buf, pos + 12, 100)
-    struct.pack_into("<i", buf, pos + 24, 0)
-    struct.pack_into("<i", buf, pos + 28, 1000)
-    struct.pack_into("<i", buf, pos - 36, 99)
-
-    pm = MagicMock()
-    pm.process_handle = MagicMock()
-    with patch("reader.get_memory_regions", return_value=[(0, len(buf))]):
+    buf = _struct_buf()
+    with patch("reader.get_memory_regions", return_value=[(_HEAP_BASE, len(buf))]):
         with patch("reader.verify_structure", return_value=1.0):
-            pm.read_bytes.return_value = bytes(buf)
-            pm.read_int.side_effect = lambda addr: struct.unpack_from("<i", buf, addr)[0]
-            result = locate_character(pm, hp, knowledge, offset_filters={})
+            result = locate_character(_fake_pm(buf), 287, knowledge, offset_filters={})
 
-    assert result == pos  # found at correct position
+    assert result == _HEAP_BASE + _POS  # found at correct heap address
 
 
 def test_locate_character_filter_match_keeps_candidate():
@@ -126,27 +126,12 @@ def test_locate_character_filter_match_keeps_candidate():
     from reader import locate_character, load_knowledge
 
     knowledge = load_knowledge()
-
-    hp = 287
-    buf = bytearray(1024)
-    pos = 228
-    struct.pack_into("<i", buf, pos, hp)
-    struct.pack_into("<i", buf, pos + 4, hp)
-    struct.pack_into("<i", buf, pos + 8, 100)
-    struct.pack_into("<i", buf, pos + 12, 100)
-    struct.pack_into("<i", buf, pos + 24, 0)
-    struct.pack_into("<i", buf, pos + 28, 1000)
-    struct.pack_into("<i", buf, pos - 36, 99)  # level = 99
-
-    pm = MagicMock()
-    pm.process_handle = MagicMock()
-    with patch("reader.get_memory_regions", return_value=[(0, len(buf))]):
+    buf = _struct_buf()
+    with patch("reader.get_memory_regions", return_value=[(_HEAP_BASE, len(buf))]):
         with patch("reader.verify_structure", return_value=1.0):
-            pm.read_bytes.return_value = bytes(buf)
-            pm.read_int.side_effect = lambda addr: struct.unpack_from("<i", buf, addr)[0]
-            result = locate_character(pm, hp, knowledge, offset_filters={-36: 99})
+            result = locate_character(_fake_pm(buf), 287, knowledge, offset_filters={-36: 99})
 
-    assert result == pos  # filter matches level=99, candidate kept
+    assert result == _HEAP_BASE + _POS  # filter matches level=99, candidate kept
 
 
 def test_locate_character_filter_read_error_drops_candidate():
@@ -154,31 +139,50 @@ def test_locate_character_filter_read_error_drops_candidate():
     from reader import locate_character, load_knowledge
 
     knowledge = load_knowledge()
-
-    hp = 287
-    buf = bytearray(1024)
-    pos = 228
-    struct.pack_into("<i", buf, pos, hp)
-    struct.pack_into("<i", buf, pos + 4, hp)
-    struct.pack_into("<i", buf, pos + 8, 100)
-    struct.pack_into("<i", buf, pos + 12, 100)
-    struct.pack_into("<i", buf, pos + 24, 0)
-    struct.pack_into("<i", buf, pos + 28, 1000)
-    struct.pack_into("<i", buf, pos - 36, 99)
-
-    pm = MagicMock()
-    pm.process_handle = MagicMock()
+    buf = _struct_buf()
 
     def read_int_raises_on_filter(addr):
-        # Normal reads work, but the filter offset (-36 relative = pos-36 = 192) raises
-        if addr == pos - 36:
+        if addr == _HEAP_BASE + _POS - 36:  # the filter offset read raises
             raise OSError("cannot read")
-        return struct.unpack_from("<i", buf, addr)[0]
+        return struct.unpack_from("<i", buf, addr - _HEAP_BASE)[0]
 
-    with patch("reader.get_memory_regions", return_value=[(0, len(buf))]):
+    with patch("reader.get_memory_regions", return_value=[(_HEAP_BASE, len(buf))]):
         with patch("reader.verify_structure", return_value=1.0):
-            pm.read_bytes.return_value = bytes(buf)
-            pm.read_int.side_effect = read_int_raises_on_filter
-            result = locate_character(pm, hp, knowledge, offset_filters={-36: 99})
+            result = locate_character(
+                _fake_pm(buf, read_int=read_int_raises_on_filter),
+                287,
+                knowledge,
+                offset_filters={-36: 99},
+            )
 
     assert result is None  # candidate dropped due to read error
+
+
+def test_locate_character_rejects_static_low_address():
+    """A struct-shaped match below the heap floor (static/module memory) is
+    rejected even when verify_structure would score it 1.0 — this is the
+    false-positive lock that froze a second client on dead memory at 0x00A3BE14.
+    """
+    from reader import locate_character, load_knowledge
+
+    knowledge = load_knowledge()
+    buf = _struct_buf()
+    low_base = 0x00A30000  # below HEAP_MIN_ADDR, like the real false positive
+    with patch("reader.get_memory_regions", return_value=[(low_base, len(buf))]):
+        with patch("reader.verify_structure", return_value=1.0):
+            result = locate_character(_fake_pm(buf, base=low_base), 287, knowledge)
+
+    assert result is None  # rejected by the heap address-range guard
+
+
+def test_locate_character_accepts_heap_address():
+    """The same struct on the heap (>= HEAP_MIN_ADDR) is kept."""
+    from reader import locate_character, load_knowledge
+
+    knowledge = load_knowledge()
+    buf = _struct_buf()
+    with patch("reader.get_memory_regions", return_value=[(_HEAP_BASE, len(buf))]):
+        with patch("reader.verify_structure", return_value=1.0):
+            result = locate_character(_fake_pm(buf), 287, knowledge)
+
+    assert result == _HEAP_BASE + _POS

--- a/tests/test_verify_structure_name.py
+++ b/tests/test_verify_structure_name.py
@@ -1,0 +1,92 @@
+"""Regression: verify_structure must reject struct-shaped memory that has no
+valid character name at NAME_OFFSET.
+
+A second game client that wasn't logged in yet caused read_hp_from_player_chain
+to return a degenerate value (1); locate_character then scanned for the int32
+`1` (the most common value in memory) and locked onto a static region that
+passed every numeric check with a perfect score but had an empty name. Because
+it never failed validation, the worker's re-locate self-healing never fired and
+the UI stayed stuck on the "(連線中)" placeholder. Requiring a real Big5 name
+distinguishes a true character struct from such false positives.
+"""
+
+from reader import verify_structure, verify_structure_shifted
+
+# Field names come from knowledge.json (Chinese by design); comments stay English.
+_FIELDS: dict = {}  # verify_* only uses fixed offsets, not this map
+
+
+class FakePm:
+    """pymem stand-in: read_int reads offsets from a dict, read_bytes returns
+    the name blob (verify_* only reads bytes for the name at NAME_OFFSET)."""
+
+    def __init__(self, ints, name=b""):
+        self._ints = ints
+        self._name = name
+
+    def read_int(self, addr):
+        return self._ints.get(addr, 0)
+
+    def read_bytes(self, addr, size):
+        return (self._name + b"\x00" * size)[:size]
+
+
+# A struct whose numeric fields all pass the hard constraints and trip no soft
+# penalty / sequential-pattern heuristic — so its score hinges solely on name.
+_NORMAL_INTS = {
+    0: 287,
+    4: 287,
+    8: 100,
+    12: 100,
+    24: 50,
+    28: 1000,
+    -36: 99,
+    -96: 10,
+    -88: 10,
+    -80: 10,
+    44: 10,
+    416: 5,
+    420: 5,
+}
+# Shifted layout: max@0, current@4, max@8, current@12.
+_SHIFTED_INTS = {
+    0: 287,
+    4: 287,
+    8: 100,
+    12: 100,
+    24: 50,
+    28: 1000,
+    -36: 99,
+    -96: 10,
+    -88: 10,
+    -80: 10,
+    44: 10,
+    416: 5,
+    420: 5,
+}
+
+
+def test_verify_structure_rejects_struct_without_name():
+    pm = FakePm(_NORMAL_INTS, name=b"")  # empty name -> not a real character
+    assert verify_structure(pm, 0, _FIELDS) == 0.0
+
+
+def test_verify_structure_accepts_struct_with_valid_big5_name():
+    pm = FakePm(_NORMAL_INTS, name="奧黑比呂".encode("big5"))
+    assert verify_structure(pm, 0, _FIELDS) >= 0.8
+
+
+def test_verify_structure_rejects_non_big5_name_bytes():
+    # Bytes that are not a valid Big5 lead/trail pair (ASCII-range garbage).
+    pm = FakePm(_NORMAL_INTS, name=b"\x01\x02\x03\x04")
+    assert verify_structure(pm, 0, _FIELDS) == 0.0
+
+
+def test_verify_structure_shifted_rejects_struct_without_name():
+    pm = FakePm(_SHIFTED_INTS, name=b"")
+    assert verify_structure_shifted(pm, 0, _FIELDS) == 0.0
+
+
+def test_verify_structure_shifted_accepts_struct_with_valid_big5_name():
+    pm = FakePm(_SHIFTED_INTS, name="晨曦破空".encode("big5"))
+    assert verify_structure_shifted(pm, 0, _FIELDS) >= 0.8

--- a/verify_name.py
+++ b/verify_name.py
@@ -2,12 +2,13 @@
 Verify character name at HP-228 offset.
 Reads the raw bytes at hp_addr - 228 and decodes as Big5 string.
 """
+
 import sys
 import struct
 import time
 import pymem
 
-sys.path.insert(0, '.')
+sys.path.insert(0, ".")
 from reader import locate_character, load_knowledge
 
 
@@ -24,24 +25,24 @@ def read_name(pm, hp_addr):
         return None, None, str(e)
 
     # Find null terminator
-    end = raw.find(b'\x00')
+    end = raw.find(b"\x00")
     if end != -1:
         raw = raw[:end]
 
     print(f"  Raw bytes at HP{NAME_OFFSET:+d} (0x{addr:08X}): {raw.hex()}")
 
-    for enc in ['big5', 'gbk', 'utf-8']:
+    for enc in ["big5", "gbk", "utf-8"]:
         try:
             text = raw.decode(enc)
             return text, enc, None
         except Exception:
             pass
 
-    return raw.hex(), 'hex', None
+    return raw.hex(), "hex", None
 
 
 def main():
-    sys.stdout.reconfigure(encoding='utf-8')
+    sys.stdout.reconfigure(encoding="utf-8")
 
     if len(sys.argv) < 2:
         print("Usage: uv run verify_name.py <current_hp>")
@@ -79,20 +80,20 @@ def main():
         print("  (empty or unreadable)")
 
     # Also dump the 32 bytes around NAME_OFFSET for inspection
-    print(f"\n  Context dump (HP-256 to HP-200):")
+    print("\n  Context dump (HP-256 to HP-200):")
     for off in range(-256, -196, 4):
         try:
             raw4 = pm.read_bytes(hp_addr + off, 4)
-            val = struct.unpack('<i', raw4)[0]
-            uval = struct.unpack('<I', raw4)[0]
+            val = struct.unpack("<i", raw4)[0]
+            uval = struct.unpack("<I", raw4)[0]
             try:
-                text = raw4.rstrip(b'\x00').decode('big5')
+                text = raw4.rstrip(b"\x00").decode("big5")
             except Exception:
-                text = ''
+                text = ""
             print(f"    HP{off:+4d}  0x{uval:08X}  ({val:10d})  {text!r}")
         except Exception:
             pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/warehouse_scan.py
+++ b/warehouse_scan.py
@@ -7,6 +7,7 @@ Requires warehouse UI to be open (data is freed when closed).
 Usage:
     uv run warehouse_scan.py <current_hp>
 """
+
 import pymem
 import struct
 import sys
@@ -17,13 +18,12 @@ from reader import (
     locate_inventory,
     locate_character,
     find_inventory_start,
-    read_inventory,
     load_item_db,
     load_knowledge,
     INVENTORY_SLOT_SIZE,
 )
 
-sys.stdout.reconfigure(encoding='utf-8')
+sys.stdout.reconfigure(encoding="utf-8")
 
 SLOT_SIZE = INVENTORY_SLOT_SIZE  # 2272 = 0x8E0
 MAX_WAREHOUSE_SLOTS = 80
@@ -33,8 +33,8 @@ def locate_all_slot_arrays(pm):
     """Find ALL item-slot arrays in memory using the same pattern as inventory.
     Returns list of addresses (first matched slot in each array)."""
     regions = get_memory_regions(pm.process_handle)
-    zero8 = b'\x00' * 8
-    zero24 = b'\x00' * 24
+    zero8 = b"\x00" * 8
+    zero24 = b"\x00" * 24
     hits = []
     found_ranges = []  # track (start, end) to avoid duplicate hits in same array
 
@@ -57,27 +57,27 @@ def locate_all_slot_arrays(pm):
             if skip:
                 continue
 
-            if buffer[pos - 8:pos] != zero8:
+            if buffer[pos - 8 : pos] != zero8:
                 continue
-            item_id = struct.unpack('<i', buffer[pos:pos + 4])[0]
+            item_id = struct.unpack("<i", buffer[pos : pos + 4])[0]
             if not (1000 <= item_id <= 65535):
                 continue
-            ptr = struct.unpack('<I', buffer[pos + 4:pos + 8])[0]
+            ptr = struct.unpack("<I", buffer[pos + 4 : pos + 8])[0]
             if not (0x01000000 <= ptr <= 0x7FFFFFFF):
                 continue
-            if buffer[pos + 8:pos + 32] != zero24:
+            if buffer[pos + 8 : pos + 32] != zero24:
                 continue
             # Verify next slot
             ns = pos + SLOT_SIZE
             if ns + 32 > len(buffer):
                 continue
-            next_id = struct.unpack('<i', buffer[ns:ns + 4])[0]
+            next_id = struct.unpack("<i", buffer[ns : ns + 4])[0]
             if not (1000 <= next_id <= 65535):
                 continue
-            next_ptr = struct.unpack('<I', buffer[ns + 4:ns + 8])[0]
+            next_ptr = struct.unpack("<I", buffer[ns + 4 : ns + 8])[0]
             if not (0x01000000 <= next_ptr <= 0x7FFFFFFF):
                 continue
-            if buffer[ns + 8:ns + 32] != zero24:
+            if buffer[ns + 8 : ns + 32] != zero24:
                 continue
 
             hits.append(addr)
@@ -97,7 +97,7 @@ def walk_back_to_start(pm, addr):
                 addr = prev
                 continue
             if 1000 <= item_id <= 65535:
-                ptr = struct.unpack('<I', pm.read_bytes(prev + 4, 4))[0]
+                ptr = struct.unpack("<I", pm.read_bytes(prev + 4, 4))[0]
                 if ptr == 0 or (0x01000000 <= ptr <= 0x7FFFFFFF):
                     addr = prev
                     continue
@@ -129,7 +129,7 @@ def read_slot_array(pm, base_addr, max_slots=MAX_WAREHOUSE_SLOTS):
 
         empty_streak = 0
         try:
-            ptr = struct.unpack('<I', pm.read_bytes(addr + 4, 4))[0]
+            ptr = struct.unpack("<I", pm.read_bytes(addr + 4, 4))[0]
             qty = pm.read_int(ptr) if (0x01000000 <= ptr <= 0x7FFFFFFF) else -1
         except Exception:
             qty = -1
@@ -206,17 +206,17 @@ def main():
         if len(items) < 2:
             continue  # skip tiny arrays (probably not warehouse)
 
-        print(f"\n{'='*60}")
-        print(f"Array #{wi+1} at 0x{arr_start:08X}  ({len(items)} items)")
-        print(f"{'='*60}")
+        print(f"\n{'=' * 60}")
+        print(f"Array #{wi + 1} at 0x{arr_start:08X}  ({len(items)} items)")
+        print(f"{'=' * 60}")
         print(f"  {'#':>3}  {'ID':>6}  {'Qty':>5}  Name")
         print(f"  {'---':>3}  {'------':>6}  {'-----':>5}  ----")
         for i, (item_id, qty, addr) in enumerate(items):
             name = item_db.get(item_id, "???")
-            print(f"  {i+1:>3}  {item_id:>6}  {qty:>5}  {name}")
+            print(f"  {i + 1:>3}  {item_id:>6}  {qty:>5}  {name}")
         print(f"  Total: {len(items)} items")
 
-    print(f"\nDone.")
+    print("\nDone.")
 
 
 if __name__ == "__main__":

--- a/webui/src/api/schema.ts
+++ b/webui/src/api/schema.ts
@@ -506,6 +506,25 @@ export interface components {
             merchant_idx: number;
         };
         /**
+         * BuffInfo
+         * @description One active status on a character. The game stores the status `group`
+         *     (not the exact status id), so `name` is the representative status name
+         *     for that group (e.g. 護體 / 血契 / 靈契 / 中毒). `kind` distinguishes the
+         *     source array: positive self-buffs (HP+0x288) vs debuffs (HP+0x4C4).
+         */
+        BuffInfo: {
+            /** Group */
+            group: number;
+            /** Name */
+            name: string;
+            /**
+             * Kind
+             * @default buff
+             * @enum {string}
+             */
+            kind: "buff" | "debuff";
+        };
+        /**
          * Character
          * @description Lightweight row used by GET /api/characters.
          */
@@ -541,6 +560,11 @@ export interface components {
             vitals: components["schemas"]["Vitals"];
             position: components["schemas"]["Position"];
             autoclick: components["schemas"]["AutoClickStatus"];
+            /**
+             * Buffs
+             * @default []
+             */
+            buffs: components["schemas"]["BuffInfo"][];
             /** Inventory */
             inventory?: components["schemas"]["Item"][] | null;
             /** Warehouse */
@@ -567,6 +591,11 @@ export interface components {
             vitals: components["schemas"]["Vitals"];
             position: components["schemas"]["Position"];
             autoclick: components["schemas"]["AutoClickStatus"];
+            /**
+             * Buffs
+             * @default []
+             */
+            buffs: components["schemas"]["BuffInfo"][];
         };
         /** CharacterStats */
         CharacterStats: {

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -8,6 +8,7 @@ export type Account = S['Account'];
 export type AutoClickConfig = S['AutoClickConfig'];
 export type AutoClickStatus = S['AutoClickStatus'];
 export type AutoClickTestRequest = S['AutoClickTestRequest'];
+export type BuffInfo = S['BuffInfo'];
 export type Character = S['Character'];
 export type CharacterDetail = S['CharacterDetail'];
 export type CharacterRow = S['CharacterRow'];

--- a/webui/src/pages/CharDetail/BodyTab.tsx
+++ b/webui/src/pages/CharDetail/BodyTab.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { get } from '../../api/client';
-import { Panel, StatNum } from '../../primitives';
+import { BuffChips, Panel, StatNum } from '../../primitives';
+import type { BuffInfo } from '../../api/types';
 
 interface Detail {
   pid: number; name: string;
@@ -8,11 +9,19 @@ interface Detail {
     waigong: number; neili: number; genggu: number; shenfa: number; jiqiao: number; xuanxue: number;
     wugong: number; wugong_base: number; neijing: number; fangyu: number; huji: number; mingzhong: number; shanduo: number;
   };
+  buffs?: BuffInfo[];
 }
 
 export function BodyTab({ pid }: { pid: number }) {
   const [d, setD] = useState<Detail | null>(null);
-  useEffect(() => { get<Detail>(`/api/characters/${pid}`).then(setD).catch(() => {}); }, [pid]);
+  useEffect(() => {
+    let alive = true;
+    const fetchOnce = () =>
+      get<Detail>(`/api/characters/${pid}`).then(x => { if (alive) setD(x); }).catch(() => {});
+    fetchOnce();                              // immediate
+    const id = setInterval(fetchOnce, 3000); // keep stats + buffs fresh, like the dashboard
+    return () => { alive = false; clearInterval(id); };
+  }, [pid]);
   if (!d) return <div style={{ color: 'var(--tt-mute)' }}>讀取中…</div>;
   const six = [
     ['外功', d.stats.waigong], ['內力', d.stats.neili], ['根骨', d.stats.genggu],
@@ -29,6 +38,9 @@ export function BodyTab({ pid }: { pid: number }) {
       </Panel>
       <Panel title="七戰">
         <Grid pairs={seven} />
+      </Panel>
+      <Panel title="狀態" style={{ gridColumn: '1 / -1' }}>
+        <BuffChips buffs={d.buffs} emptyText="目前無增益狀態" />
       </Panel>
     </div>
   );

--- a/webui/src/pages/Dashboard.tsx
+++ b/webui/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { post } from '../api/client';
 import type { CharacterRow, OkResponse } from '../api/types';
-import { Bar, LinkDot, Panel, StatNum } from '../primitives';
+import { Bar, BuffChips, LinkDot, Panel, StatNum } from '../primitives';
 
 export function Dashboard({
   chars, onPick,
@@ -38,14 +38,17 @@ export function Dashboard({
               onClick={() => onPick(c)}
               onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onPick(c); }}
               style={{
-                display: 'grid',
-                gridTemplateColumns: '24px minmax(0, 1fr) 40px 88px 88px 88px 72px 72px',
-                gap: 10, alignItems: 'center', padding: 12,
+                display: 'flex', flexDirection: 'column', gap: 8, padding: 12,
                 background: 'var(--tt-raised)', border: '1px solid var(--tt-line-soft)',
                 color: 'var(--tt-text)', cursor: 'pointer', textAlign: 'left',
                 opacity: c.link === 'lost' ? 0.65 : 1,
               }}
             >
+              <div style={{
+                display: 'grid',
+                gridTemplateColumns: '24px minmax(0, 1fr) 40px 88px 88px 88px 72px 72px',
+                gap: 10, alignItems: 'center',
+              }}>
               <LinkDot status={c.link} />
               <div style={{ display: 'grid', gap: 2, minWidth: 0 }}>
                 <span style={{ fontFamily: 'var(--tt-font-serif)', letterSpacing: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.name}</span>
@@ -74,6 +77,8 @@ export function Dashboard({
               >
                 {rescanning === c.pid ? '偵測中…' : '↻ 重偵'}
               </button>
+              </div>
+              <BuffChips buffs={c.buffs} />
             </div>
           ))}
         </div>

--- a/webui/src/primitives/BuffChips.tsx
+++ b/webui/src/primitives/BuffChips.tsx
@@ -1,0 +1,45 @@
+import type { BuffInfo } from '../api/types';
+
+/**
+ * Row of active-status chips. The game stores a status `group`, so each chip
+ * shows the representative group name (e.g. 護體 / 血契 / 中毒). A gold pill
+ * marks a positive buff, a red pill a debuff — but the name (not colour alone)
+ * carries the meaning, and `title` exposes the group id + kind for
+ * accessibility. Driven by whatever the backend reports, so any status array
+ * added in knowledge.json shows up here automatically.
+ */
+export function BuffChips({ buffs, emptyText }: { buffs?: BuffInfo[]; emptyText?: string }) {
+  if (!buffs || buffs.length === 0) {
+    return emptyText
+      ? <span style={{ color: 'var(--tt-mute)', fontSize: 11 }}>{emptyText}</span>
+      : null;
+  }
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+      {buffs.map((b, i) => {
+        const isDebuff = b.kind === 'debuff';
+        const accent = isDebuff ? 'var(--tt-bad)' : 'var(--tt-gold)';
+        return (
+          <span
+            key={`${b.group}-${i}`}
+            title={`${b.name}（group ${b.group}・${isDebuff ? '負面' : '增益'}）`}
+            style={{
+              fontSize: 11,
+              lineHeight: 1.5,
+              padding: '1px 8px',
+              background: 'var(--tt-raised)',
+              border: `1px solid ${accent}`,
+              color: accent,
+              borderRadius: 10,
+              whiteSpace: 'nowrap',
+              fontFamily: 'var(--tt-font-serif)',
+              letterSpacing: 1,
+            }}
+          >
+            {b.name}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/webui/src/primitives/index.ts
+++ b/webui/src/primitives/index.ts
@@ -1,4 +1,5 @@
 export { Bar } from './Bar';
+export { BuffChips } from './BuffChips';
 export { LinkDot, type LinkStatus } from './LinkDot';
 export { Seal } from './Seal';
 export { Panel } from './Panel';


### PR DESCRIPTION
## What

Config-driven active-status display, plus the correctness fixes surfaced while reviewing it.

### Feature — systematic buff/debuff display
- Reads **every** status array declared in `knowledge.json` (positive buffs at `HP+0x288`, debuffs at `HP+0x4C4`) and resolves each status `group` via the full `tthol.sqlite`, instead of hard-coding one status at a time.
- Adding a new status category needs only a `knowledge.json` entry (count/array offsets + `kind`) — no code change.
- `reader.py`: `read_status_array` / `read_active_statuses` (config-driven); `read_active_buffs` kept as a back-compat shim.
- `worker → char_session → api_types`: thread `(group, name, kind)` to a new `BuffInfo.kind`. Dashboard cards + CharDetail render **gold** buff chips / **red** debuff chips.
- `app.py`: rotating-file logger (`tthol-reader.log`) so worker locate/read failures are diagnosable.

### Fixes from code review
- **Compat-layout vitals bug:** when a character is located in the 4-byte-shifted "compat" layout, `read_all_fields` now remaps offsets `0↔4` (HP/maxHP) and `8↔12` (MP/maxMP) so current/max are not displayed swapped. Reachable because the worker auto-falls back to compat layout. Covered by `tests/test_read_all_fields_compat.py`.
- **`load_status_db`:** close the SQLite connection on the error path via `try/finally` (sqlite's `with` only manages the transaction, not the handle).
- **`.gitignore`:** ignore runtime `*.log` and local RE scratch scripts.

## Testing
- `uv run pytest` → **51 passed** (incl. 4 new compat tests).
- `npm run gen-types` + `npm run build` regenerated/rebuilt cleanly.

## Notes / out of scope
- The 6 `ruff` E722/E741 warnings in `reader.py` are **pre-existing** (locate/verify/map heuristics), not introduced here.
- Standalone CLIs (`auto_detect.py`, `warehouse_scan.py`, `reader.py` CLI) remain compat-blind — a **pre-existing** gap, deferred. The GUI path is fully compat-correct.
- Known limitation unchanged: 默念 pure-stat buffs (e.g. 冰心靈訣) are render-layer only and never enter either status array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)