### PR TITLE
fix: locate characters with pure-numeric / ASCII names

### DIFF
--- a/reader.py
+++ b/reader.py
@@ -158,34 +158,52 @@ NAME_OFFSET = -228
 NAME_MAX_BYTES = 32
 
 
+def _is_name_char(ch: str) -> bool:
+    """True for a character that can legitimately appear in a character name.
+
+    Names are CJK ideographs and/or ASCII alphanumerics, occasionally with
+    printable punctuation (e.g. an underscore). Rather than allow-list those
+    categories -- which would newly reject the punctuation the previous rule
+    accepted -- this rejects only what marks struct-shaped garbage: C0/C1
+    control bytes, space, and DEL. Everything else that decoded cleanly as Big5
+    is treated as a name character.
+    """
+    o = ord(ch)
+    return o > 0x20 and o != 0x7F and not (0x80 <= o <= 0x9F)
+
+
 def _has_valid_character_name(pm, struct_base):
-    """True when a Big5 character name sits at NAME_OFFSET.
+    """True when a plausible character name sits at NAME_OFFSET.
 
     A genuine character always has a name there; struct-shaped garbage (static
     data, freed heap) does not. Used as a hard constraint in verify_structure to
     reject false positives that satisfy the numeric checks but are not real
-    characters. Requires the first character to be a valid Big5 double-byte
-    (names start with a CJK glyph) and the whole name to decode as Big5.
+    characters.
+
+    The name must be null-terminated within the 32-byte field, decode cleanly as
+    Big5, and consist solely of name characters (CJK ideographs or ASCII
+    alphanumerics). Admitting ASCII lets pure-numeric and English names through
+    -- they are single-byte in Big5 and were wrongly rejected by the previous
+    "first byte must be a Big5 lead byte / name must be an even byte count" rule,
+    which left such characters stuck forever on the "(連線中)" placeholder. The
+    all-name-char + null-terminated requirement still rejects empty names and
+    control-byte / random-heap garbage.
     """
     try:
         raw = pm.read_bytes(struct_base + NAME_OFFSET, NAME_MAX_BYTES)
     except Exception:
         return False
     # A real name is null-terminated within the 32-byte field (padded after).
-    # Garbage heap with no terminator in the window is not a character name.
+    # Garbage heap with no terminator near the start is not a character name.
     end = raw.find(b"\x00")
-    if end < 2:
+    if end < 1:
         return False
     raw = raw[:end]
-    if len(raw) % 2 != 0:  # Big5 names are whole double-byte characters
-        return False
-    if not (0xA1 <= raw[0] <= 0xF9 and 0x40 <= raw[1] <= 0xFE):
-        return False
     try:
-        raw.decode("big5")
+        name = raw.decode("big5")
     except Exception:
         return False
-    return True
+    return all(_is_name_char(ch) for ch in name)
 
 
 def locate_character(pm, hp_value, knowledge, offset_filters=None, compat_mode=False):

--- a/tests/test_verify_structure_name.py
+++ b/tests/test_verify_structure_name.py
@@ -90,3 +90,41 @@ def test_verify_structure_shifted_rejects_struct_without_name():
 def test_verify_structure_shifted_accepts_struct_with_valid_big5_name():
     pm = FakePm(_SHIFTED_INTS, name="晨曦破空".encode("big5"))
     assert verify_structure_shifted(pm, 0, _FIELDS) >= 0.8
+
+
+# Pure-numeric (and other pure-ASCII) character names are legal in-game. They
+# are single-byte in Big5, so the old "first byte is a Big5 lead byte + whole
+# name is an even number of bytes" rule rejected them, leaving such characters
+# permanently stuck on the "(連線中)" placeholder. The name check must admit
+# alphanumeric names while still rejecting empty / control-byte garbage.
+def test_verify_structure_accepts_pure_numeric_name():
+    pm = FakePm(_NORMAL_INTS, name=b"12345")  # odd byte length, ASCII digits
+    assert verify_structure(pm, 0, _FIELDS) >= 0.8
+
+
+def test_verify_structure_accepts_even_length_numeric_name():
+    pm = FakePm(_NORMAL_INTS, name=b"1234")  # even length, ASCII-leading
+    assert verify_structure(pm, 0, _FIELDS) >= 0.8
+
+
+def test_verify_structure_accepts_alphanumeric_name():
+    pm = FakePm(_NORMAL_INTS, name=b"Player1")
+    assert verify_structure(pm, 0, _FIELDS) >= 0.8
+
+
+def test_verify_structure_accepts_mixed_ascii_and_big5_name():
+    pm = FakePm(_NORMAL_INTS, name="6之".encode("big5"))
+    assert verify_structure(pm, 0, _FIELDS) >= 0.8
+
+
+def test_verify_structure_accepts_name_with_printable_punctuation():
+    # Underscores / printable punctuation appear in real names. The previous
+    # rule accepted any clean Big5 decode, so the fix must not newly reject
+    # these (that would just trade one stuck-on-"(連線中)" bug for another).
+    pm = FakePm(_NORMAL_INTS, name=b"Player_1")
+    assert verify_structure(pm, 0, _FIELDS) >= 0.8
+
+
+def test_verify_structure_shifted_accepts_pure_numeric_name():
+    pm = FakePm(_SHIFTED_INTS, name=b"7788")
+    assert verify_structure_shifted(pm, 0, _FIELDS) >= 0.8


### PR DESCRIPTION
## 問題

玩家回報:**純數字帳號/角色名**的角色一直卡在「(連線中)」,重連也無法恢復;單開該帳號同樣連不上。

## 根因

`reader.py` 的 `_has_valid_character_name`(`verify_structure` / `verify_structure_shifted` 的硬性條件)假設名字一定是 Big5 雙位元組 CJK:

- 要求整體為**偶數位元組**(`len(raw) % 2 != 0` → 拒)
- 要求**首位元組是 Big5 lead byte**(`0xA1 <= raw[0] <= 0xF9`)

純數字 / 英文名在 Big5 是單位元組 ASCII,兩條都踩中 → `verify_structure` 回 `0.0` → `locate_character` 永遠找不到角色 → 卡在 `_placeholder_row` 的「(連線中)」。

## 修正

改用「Big5 解碼 + 只拒絕控制字元 / 空白 / DEL」來驗證名稱。這樣:

- ✅ 純數字、英文、含底線等合法名稱都能通過
- ✅ 仍拒絕空名與控制位元組(`\x01\x02...`)這類 struct-shaped heap 垃圾(沿用既有回歸測試的保護)

刻意採用「黑名單(擋垃圾特徵)」而非「白名單(只允許 CJK+英數)」,避免把 `Player_1` 這類含標點的合法名誤殺、換成另一種卡連線中。

## 測試

- TDD:先寫失敗測試(純數字 / 偶數長數字 / 英數 / 中英混合 / 含底線 / shifted 版純數字)再實作。
- `tests/test_verify_structure_name.py` 11 passed;既有「空名」「控制位元組」回歸測試仍綠。
- 完整套件 `uv run pytest` 全綠;`ruff check` 乾淨。

> ⚠️ 無法在 CI 外接真實遊戲行程,建議合併後拿純數字帳號實測一次「能否掃出/連上」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)